### PR TITLE
feat(paycard): create_payment spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,20 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@types/node": "^22.0.0",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "typescript": "^6.0.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/ajv": {
@@ -103,6 +114,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "devDependencies": {
     "typescript": "^6.0.2",
     "ajv": "^8.18.0",
-    "ajv-formats": "^3.0.1"
+    "ajv-formats": "^3.0.1",
+    "@types/node": "^22.0.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -225,7 +225,7 @@ function validateTypeScript(specPath) {
 
   try {
     execSync(
-      `"${tscBin}" --noEmit --strict --target ES2020 --module ESNext --moduleResolution bundler --lib ES2020,DOM "${tsPath}"`,
+      `"${tscBin}" --noEmit --strict --target ES2020 --module ESNext --moduleResolution bundler --lib ES2020,DOM --types node "${tsPath}"`,
       { stdio: "pipe" }
     );
   } catch (err) {

--- a/specs/payment/paycard/create_payment/canonical_example.ts
+++ b/specs/payment/paycard/create_payment/canonical_example.ts
@@ -1,0 +1,90 @@
+/**
+ * @provider Paycard
+ * @capability create_payment
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const PAYCARD_API_KEY = process.env.PAYCARD_API_KEY;
+if (!PAYCARD_API_KEY) throw new Error("Missing env: PAYCARD_API_KEY");
+
+interface CreatePaymentInput {
+  amount: number;
+  description?: string;
+  reference?: string;
+  callbackUrl?: string;
+  autoRedirect?: boolean;
+  redirectWithGet?: boolean;
+  paymentMethod?: "PAYCARD" | "CREDIT_CARD" | "ORANGE_MONEY" | "MOMO";
+}
+
+interface CreatePaymentResponse {
+  code: number;
+  "paycard-payment-url": string;
+  "paycard-operation-reference": string;
+  "paycard-amount": string;
+  "paycard-description": string;
+}
+
+interface PaycardError {
+  code: number;
+  error_message: string;
+}
+
+export async function createPayment(
+  input: CreatePaymentInput
+): Promise<CreatePaymentResponse> {
+  const body: Record<string, string> = {
+    c: PAYCARD_API_KEY!, // guarded at module level above
+    "paycard-amount": String(input.amount),
+  };
+
+  if (input.description) body["paycard-description"] = input.description;
+  if (input.reference) body["paycard-operation-reference"] = input.reference;
+  if (input.callbackUrl) body["paycard-callback-url"] = input.callbackUrl;
+  if (input.autoRedirect !== undefined)
+    body["paycard-auto-redirect"] = input.autoRedirect ? "on" : "off";
+  if (input.redirectWithGet !== undefined)
+    body["paycard-redirect-with-get"] = input.redirectWithGet ? "on" : "off";
+
+  if (input.paymentMethod === "PAYCARD") body["paycard-jump-to-paycard"] = "on";
+  if (input.paymentMethod === "CREDIT_CARD") body["paycard-jump-to-cc"] = "on";
+  if (input.paymentMethod === "ORANGE_MONEY") body["paycard-jump-to-om"] = "on";
+  if (input.paymentMethod === "MOMO") body["paycard-jump-to-momo"] = "on";
+
+  const response = await fetch("https://mapaycard.com/epay/create/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  const data: CreatePaymentResponse | PaycardError = await response.json();
+
+  if ((data as PaycardError).code !== 0) {
+    const err = data as PaycardError;
+    throw new Error(`Paycard error ${err.code}: ${err.error_message}`);
+  }
+
+  return data as CreatePaymentResponse;
+}
+
+/*
+Usage example:
+
+const payment = await createPayment({
+  amount: 100000,
+  description: "Order #123",
+  reference: "order_123",
+  callbackUrl: "https://myapp.com/payment/callback",
+  autoRedirect: true,
+  redirectWithGet: true,
+  paymentMethod: "ORANGE_MONEY",
+});
+
+// Redirect the user to the payment page
+// window.location.href = payment["paycard-payment-url"];
+
+// Store payment["paycard-operation-reference"] in your database
+// before redirecting — you need it to verify the payment server-side.
+// Never fulfill an order based on the callback URL alone.
+*/

--- a/specs/payment/paycard/create_payment/schema.json
+++ b/specs/payment/paycard/create_payment/schema.json
@@ -1,0 +1,123 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "paycard",
+  "provider_name": "Paycard",
+  "provider_api_version": "2024-01-01",
+  "category": "payment",
+  "capability": "create_payment",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://mapaycard.com",
+  "auth": {
+    "type": "api_key",
+    "location": "body",
+    "field": "c",
+    "format": "{token}",
+    "env_var": "PAYCARD_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://mapaycard.com/epay/create/"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["paycard-amount"],
+    "properties": {
+      "paycard-amount": {
+        "type": "integer",
+        "description": "Amount in GNF. Must be greater than 0."
+      },
+      "paycard-description": {
+        "type": "string",
+        "description": "Human-readable description of the order."
+      },
+      "paycard-operation-reference": {
+        "type": "string",
+        "description": "Your own reference for this transaction. If omitted, Paycard generates one."
+      },
+      "paycard-callback-url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL Paycard will POST to when the payment completes."
+      },
+      "paycard-auto-redirect": {
+        "type": "string",
+        "enum": ["on", "off"],
+        "description": "Whether to redirect the user automatically after payment."
+      },
+      "paycard-redirect-with-get": {
+        "type": "string",
+        "enum": ["on", "off"],
+        "description": "Append paycard-operation-reference as a query param on redirect."
+      },
+      "paycard-jump-to-paycard": {
+        "type": "string",
+        "enum": ["on"],
+        "description": "Skip payment method selection and go directly to Paycard wallet."
+      },
+      "paycard-jump-to-cc": {
+        "type": "string",
+        "enum": ["on"],
+        "description": "Skip payment method selection and go directly to credit card."
+      },
+      "paycard-jump-to-om": {
+        "type": "string",
+        "enum": ["on"],
+        "description": "Skip payment method selection and go directly to Orange Money."
+      },
+      "paycard-jump-to-momo": {
+        "type": "string",
+        "enum": ["on"],
+        "description": "Skip payment method selection and go directly to MTN MoMo."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "integer",
+        "description": "0 on success."
+      },
+      "paycard-payment-url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL to redirect the user to complete the payment."
+      },
+      "paycard-operation-reference": {
+        "type": "string",
+        "description": "Transaction reference. Store this to verify the payment later."
+      },
+      "paycard-amount": {
+        "type": "string",
+        "description": "Amount echoed back as a string."
+      },
+      "paycard-description": {
+        "type": "string",
+        "description": "Description echoed back."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "integer",
+        "description": "Non-zero error code."
+      },
+      "error_message": {
+        "type": "string",
+        "description": "Human-readable error description."
+      }
+    }
+  },
+  "gotchas": [
+    "Always verify payment status server-side by calling verify_payment before fulfilling an order. The callback URL alone is not sufficient — it can be spoofed by anyone who knows your endpoint.",
+    "Store paycard-operation-reference from the response immediately. It is the only way to verify the payment status later. If you passed your own reference, use that.",
+    "Auth is the field 'c' sent in the POST body, not an HTTP header. Do not confuse it with a Bearer token or X-Api-Key pattern.",
+    "There is no sandbox environment. All requests hit production. Use minimal amounts (e.g. 100 GNF) when testing."
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the `create_payment` spec for Paycard — first ATSS-compliant spec in the registry.
Also fixes the validation script to support `process.env` in canonical examples (`@types/node` + `--types node`).

## Spec checklist

- [x] Folder: `specs/payment/paycard/create_payment/`
- [x] Contains exactly `schema.json` + `canonical_example.ts` — nothing else
- [x] All required ATSS fields present in `schema.json`
- [x] `gotchas[]` has 4 specific, actionable entries
- [x] `canonical_example.ts` uses native fetch only (no npm imports)
- [x] `canonical_example.ts` reads credentials from `process.env`
- [x] `npm run validate` passes with zero errors
- [x] `status` set to `compliant`

## Type of change

- [x] New spec
- [x] Tooling / CI