### PR TITLE
fix(paycard): correct response fields and verify_payment endpoint

### DIFF
--- a/specs/payment/paycard/create_payment/canonical_example.ts
+++ b/specs/payment/paycard/create_payment/canonical_example.ts
@@ -20,10 +20,12 @@ interface CreatePaymentInput {
 
 interface CreatePaymentResponse {
   code: number;
-  "paycard-payment-url": string;
-  "paycard-operation-reference": string;
-  "paycard-amount": string;
-  "paycard-description": string;
+  error_message: string;
+  operation_reference: string;
+  payment_amount: number;
+  payment_amount_formatted: string;
+  payment_description: string;
+  payment_url: string;
 }
 
 interface PaycardError {
@@ -82,9 +84,9 @@ const payment = await createPayment({
 });
 
 // Redirect the user to the payment page
-// window.location.href = payment["paycard-payment-url"];
+// window.location.href = payment.payment_url;
 
-// Store payment["paycard-operation-reference"] in your database
-// before redirecting — you need it to verify the payment server-side.
+// Store payment.operation_reference in your database
+// before redirecting — you need it to call verify_payment server-side.
 // Never fulfill an order based on the callback URL alone.
 */

--- a/specs/payment/paycard/create_payment/schema.json
+++ b/specs/payment/paycard/create_payment/schema.json
@@ -64,7 +64,7 @@
           "on",
           "off"
         ],
-        "description": "Append paycard-operation-reference as a query param on redirect."
+        "description": "When 'on', Paycard redirects the user's browser to paycard-callback-url with the operation_reference as a GET query param instead of sending a server-to-server POST. Your callback route must handle GET and call verify_payment server-side."
       },
       "paycard-jump-to-paycard": {
         "type": "string",
@@ -103,22 +103,30 @@
         "type": "integer",
         "description": "0 on success."
       },
-      "paycard-payment-url": {
+      "error_message": {
         "type": "string",
-        "format": "uri",
-        "description": "URL to redirect the user to complete the payment."
+        "description": "Empty string on success."
       },
-      "paycard-operation-reference": {
+      "operation_reference": {
         "type": "string",
-        "description": "Transaction reference. Store this to verify the payment later."
+        "description": "Transaction reference. Store this before redirecting — required to call verify_payment later."
       },
-      "paycard-amount": {
+      "payment_amount": {
+        "type": "integer",
+        "description": "Amount in GNF."
+      },
+      "payment_amount_formatted": {
         "type": "string",
-        "description": "Amount echoed back as a string."
+        "description": "Human-readable amount, e.g. '65 000 GNF'."
       },
-      "paycard-description": {
+      "payment_description": {
         "type": "string",
         "description": "Description echoed back."
+      },
+      "payment_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL to redirect the user to complete the payment. Format: https://mapaycard.com/epay/{api_key}/{reference}/"
       }
     }
   },
@@ -137,8 +145,9 @@
   },
   "gotchas": [
     "Always verify payment status server-side by calling verify_payment before fulfilling an order. The callback URL alone is not sufficient — it can be spoofed by anyone who knows your endpoint.",
-    "Store paycard-operation-reference from the response immediately. It is the only way to verify the payment status later. If you passed your own reference, use that.",
+    "Store operation_reference from the response immediately. It is the only way to call verify_payment later. If you passed your own paycard-operation-reference in the request, that same value is echoed back.",
     "Auth is the field 'c' sent in the POST body, not an HTTP header. Do not confuse it with a Bearer token or X-Api-Key pattern.",
-    "There is no sandbox environment. All requests hit production. Use minimal amounts (e.g. 100 GNF) when testing."
+    "There is no sandbox environment. All requests hit production. Use minimal amounts (e.g. 100 GNF) when testing.",
+    "paycard-redirect-with-get: 'on' changes the callback from a server-to-server POST to a browser GET redirect. Your callback route must handle GET requests and still call verify_payment server-side before fulfilling the order."
   ]
 }

--- a/specs/payment/paycard/verify_payment/canonical_example.ts
+++ b/specs/payment/paycard/verify_payment/canonical_example.ts
@@ -10,10 +10,19 @@ if (!PAYCARD_API_KEY) throw new Error("Missing env: PAYCARD_API_KEY");
 
 interface VerifyPaymentResponse {
   code: number;
-  "paycard-transaction-date": string;
-  "paycard-payment-method": string;
-  "paycard-amount": string;
-  "paycard-formatted-amount": string;
+  error_message: string;
+  reference: string;
+  payment_amount: number;
+  payment_amount_formatted: string;
+  merchant_name: string;
+  status: string;
+  status_description: string | null;
+  ecommerce_description: string | null;
+  payment_method: string | null;
+  payment_method_reference: string | null;
+  payment_reference: string | null;
+  payment_description: string | null;
+  transaction_date: string | null;
 }
 
 interface PaycardError {
@@ -21,17 +30,16 @@ interface PaycardError {
   error_message: string;
 }
 
+function isPaid(status: string | null | undefined): boolean {
+  return status?.toLowerCase() === "success";
+}
+
 export async function verifyPayment(
   reference: string
 ): Promise<VerifyPaymentResponse> {
-  const url = new URL("https://mapaycard.com/epay/verify/");
-  url.searchParams.set("c", PAYCARD_API_KEY!); // guarded at module level above
-  url.searchParams.set("ref", reference);
+  const url = `https://mapaycard.com/epay/${PAYCARD_API_KEY!}/${reference}/status`;
 
-  const response = await fetch(url.toString(), {
-    method: "GET",
-    headers: { "Content-Type": "application/json" },
-  });
+  const response = await fetch(url, { method: "GET" });
 
   const data: VerifyPaymentResponse | PaycardError = await response.json();
 
@@ -47,13 +55,14 @@ export async function verifyPayment(
 Usage example:
 
 // After receiving the webhook or redirect, verify server-side before fulfilling:
-const status = await verifyPayment("2312-Z1LISQM9IY");
+const result = await verifyPayment("2604-PR700IACRG");
 
-if (status.code === 0) {
+if (isPaid(result.status)) {
   // Payment confirmed — safe to fulfill the order
-  console.log("Paid:", status["paycard-formatted-amount"]);
-  console.log("Method:", status["paycard-payment-method"]);
+  console.log("Paid:", result.payment_amount_formatted);
+  console.log("Method:", result.payment_method);
 } else {
-  // Payment pending or failed — do not fulfill
+  // Payment pending (status: 'new') or unknown — do not fulfill
+  console.log("Status:", result.status);
 }
 */

--- a/specs/payment/paycard/verify_payment/schema.json
+++ b/specs/payment/paycard/verify_payment/schema.json
@@ -14,26 +14,22 @@
   "docs_public": false,
   "auth": {
     "type": "api_key",
-    "location": "query",
+    "location": "path",
     "field": "c",
     "format": "{token}",
     "env_var": "PAYCARD_API_KEY"
   },
   "endpoint": {
     "method": "GET",
-    "url": "https://mapaycard.com/epay/verify/"
+    "url": "https://mapaycard.com/epay/{c}/{ref}/status"
   },
   "input_schema": {
     "type": "object",
-    "required": ["c", "ref"],
+    "required": ["ref"],
     "properties": {
-      "c": {
-        "type": "string",
-        "description": "API key passed as a query parameter."
-      },
       "ref": {
         "type": "string",
-        "description": "The paycard-operation-reference returned by create_payment."
+        "description": "The operation_reference returned by create_payment."
       }
     }
   },
@@ -42,23 +38,55 @@
     "properties": {
       "code": {
         "type": "integer",
-        "description": "0 means the payment succeeded."
+        "description": "0 means the transaction was found. Check the status field to confirm payment."
       },
-      "paycard-transaction-date": {
+      "error_message": {
         "type": "string",
-        "description": "Date and time of the transaction."
+        "description": "Empty string on success."
       },
-      "paycard-payment-method": {
+      "reference": {
         "type": "string",
-        "description": "Method used (e.g. ORANGE_MONEY, MOMO, CREDIT_CARD, PAYCARD)."
+        "description": "The transaction reference."
       },
-      "paycard-amount": {
-        "type": "string",
-        "description": "Amount paid as a string."
+      "payment_amount": {
+        "type": "integer",
+        "description": "Amount in GNF."
       },
-      "paycard-formatted-amount": {
+      "payment_amount_formatted": {
         "type": "string",
-        "description": "Human-readable amount with currency (e.g. '100 000 GNF')."
+        "description": "Human-readable amount, e.g. '65 000 GNF'."
+      },
+      "merchant_name": {
+        "type": "string",
+        "description": "Name of the merchant account."
+      },
+      "status": {
+        "type": "string",
+        "description": "Payment status. Known values: 'new' (pending, do not fulfill), 'success' (paid). Check case-insensitively. Paycard does not document all possible values."
+      },
+      "status_description": {
+        "type": ["string", "null"]
+      },
+      "ecommerce_description": {
+        "type": ["string", "null"],
+        "description": "Order description echoed back."
+      },
+      "payment_method": {
+        "type": ["string", "null"],
+        "description": "Method used, e.g. ORANGE_MONEY, MOMO, CREDIT_CARD, PAYCARD. Null until payment completes."
+      },
+      "payment_method_reference": {
+        "type": ["string", "null"]
+      },
+      "payment_reference": {
+        "type": ["string", "null"]
+      },
+      "payment_description": {
+        "type": ["string", "null"]
+      },
+      "transaction_date": {
+        "type": ["string", "null"],
+        "description": "Date and time of the transaction. Null until payment completes."
       }
     }
   },
@@ -67,7 +95,7 @@
     "properties": {
       "code": {
         "type": "integer",
-        "description": "Non-zero: payment is pending, failed, or the reference is unknown."
+        "description": "Non-zero: transaction not found or invalid reference."
       },
       "error_message": {
         "type": "string",
@@ -76,8 +104,9 @@
     }
   },
   "gotchas": [
-    "code: 0 means the payment succeeded. Any other value — including pending — means you must not fulfill the order.",
+    "code: 0 means the transaction was found, NOT that it was paid. Always check status: treat status?.toLowerCase() === 'success' as confirmed. status: 'new' means pending — do not fulfill.",
     "Always call this endpoint server-side before fulfilling an order. Never trust the redirect URL or callback payload alone.",
-    "The 'ref' parameter is the paycard-operation-reference returned by create_payment, not your own internal order ID."
+    "The ref path parameter is the operation_reference returned by create_payment, not your own internal order ID.",
+    "The API key (c) is a path segment in the URL, not a query parameter: GET /epay/{c}/{ref}/status."
   ]
 }

--- a/specs/payment/paycard/webhook_payment_completed/canonical_example.ts
+++ b/specs/payment/paycard/webhook_payment_completed/canonical_example.ts
@@ -14,10 +14,19 @@ interface PaycardWebhookPayload {
 
 interface VerifyPaymentResponse {
   code: number;
-  "paycard-transaction-date": string;
-  "paycard-payment-method": string;
-  "paycard-amount": string;
-  "paycard-formatted-amount": string;
+  error_message: string;
+  reference: string;
+  payment_amount: number;
+  payment_amount_formatted: string;
+  merchant_name: string;
+  status: string;
+  status_description: string | null;
+  ecommerce_description: string | null;
+  payment_method: string | null;
+  payment_method_reference: string | null;
+  payment_reference: string | null;
+  payment_description: string | null;
+  transaction_date: string | null;
 }
 
 interface PaycardError {
@@ -25,12 +34,14 @@ interface PaycardError {
   error_message: string;
 }
 
-async function verifyPayment(reference: string): Promise<VerifyPaymentResponse> {
-  const url = new URL("https://mapaycard.com/epay/verify/");
-  url.searchParams.set("c", PAYCARD_API_KEY!); // guarded at module level above
-  url.searchParams.set("ref", reference);
+function isPaid(status: string | null | undefined): boolean {
+  return status?.toLowerCase() === "success";
+}
 
-  const response = await fetch(url.toString());
+async function verifyPayment(reference: string): Promise<VerifyPaymentResponse> {
+  const url = `https://mapaycard.com/epay/${PAYCARD_API_KEY!}/${reference}/status`;
+
+  const response = await fetch(url);
   const data: VerifyPaymentResponse | PaycardError = await response.json();
 
   if ((data as PaycardError).code !== 0) {
@@ -58,10 +69,10 @@ export async function handlePaycardWebhook(
 
   try {
     // Never trust the webhook payload alone — verify server-side.
-    const status = await verifyPayment(reference);
+    const result = await verifyPayment(reference);
 
-    if (status.code === 0) {
-      await fulfillOrder(reference, status["paycard-amount"]);
+    if (isPaid(result.status)) {
+      await fulfillOrder(reference, result.payment_amount_formatted);
     }
   } catch {
     // Log and alert — do not rethrow. The 200 is already sent.

--- a/specs/payment/paycard/webhook_payment_completed/schema.json
+++ b/specs/payment/paycard/webhook_payment_completed/schema.json
@@ -35,8 +35,9 @@
   },
   "error_schema": {},
   "gotchas": [
-    "Never fulfill an order based on the webhook payload alone. Always call verify_payment with the paycard-operation-reference to confirm the payment server-side before doing anything.",
+    "Never fulfill an order based on the webhook payload alone. Always call verify_payment (GET /epay/{c}/{ref}/status) with the operation reference to confirm server-side. Check that status?.toLowerCase() === 'success' — code: 0 alone does not confirm payment.",
     "Return HTTP 200 immediately. Paycard does not retry failed webhook deliveries — if your handler throws or times out, the notification is lost.",
-    "Paycard sends no webhook signature. Anyone who knows your callback URL can POST to it. The only safe verification is calling verify_payment with the API key."
+    "Paycard sends no webhook signature. Anyone who knows your callback URL can POST to it. The only safe verification is calling verify_payment with the API key.",
+    "If create_payment was called with paycard-redirect-with-get: 'on', Paycard sends a browser GET redirect instead of this server-to-server POST. In that case, your callback route must handle GET (not POST) and extract operation_reference from the query string."
   ]
 }


### PR DESCRIPTION
## Summary

- **create_payment**: champs de réponse corrigés pour correspondre à l'API réelle — suppression du préfixe `paycard-`, renommage en snake_case (`payment_url`, `operation_reference`, `payment_amount`, etc.)
- **verify_payment**: changement d'endpoint de `/epay/verify/?c=&ref=` vers `/epay/{c}/{ref}/status` (auth en path param); response schema entièrement reécrit avec les vrais champs (`status`, `payment_method`, `transaction_date`, etc.)
- **webhook**: fonction `verifyPayment` mise à jour vers le nouvel endpoint; logique de succès `code===0` remplacée par `isPaid(status)` qui vérifie `status?.toLowerCase() === 'success'`
- **Nouveau gotcha**: `paycard-redirect-with-get: 'on'` change le callback d'un POST server-to-server vers un GET browser redirect — documenté dans create_payment et webhook

## Test plan

- [ ] Supprimer `specs/payment/paycard/verify_payment/example-laravel.txt` (fichier de référence temporaire) puis lancer `npm run validate` — doit passer 3/3
- [ ] Tester create_payment et vérifier que `operation_reference` + `payment_url` sont bien présents dans la réponse
- [ ] Tester verify_payment avec la `operation_reference` → ne doit plus retourner "Transaction introuvable"
- [ ] Vérifier que `status === 'success'` après un paiement complété

🤖 Generated with [Claude Code](https://claude.com/claude-code)