### PR TITLE
chore(plugin): improve skill triggering, add request_spec fallback, fix examples

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   "homepage": "https://afro.tools",
   "repository": "https://github.com/afrotools/afrotools",
   "license": "Apache-2.0",
-  "keywords": ["africa", "payment", "sms", "paycard", "wave", "mcp"]
+  "keywords": ["africa", "payment", "sms", "paycard", "lengopay", "wave", "djomy", "bictorys", "nimbasms", "mobile-money", "fintech", "checkout", "otp", "webhook", "mcp", "api", "integration"]
 }

--- a/plugin/skills/payment/SKILL.md
+++ b/plugin/skills/payment/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: afrotools-payment
 description: >
-  Activate when the user is integrating a payment API from an African provider
-  (Paycard, Wave, LengoPay, Djomy, Bictorys, or any payment provider in the
-  Afro.tools registry). Automatically fetches the right spec via MCP so the
-  agent knows the exact endpoint, auth format, input/output schemas, and
-  integration gotchas before writing any code.
+  Use this skill whenever the user wants to integrate, implement, or test a
+  payment API from an African provider — including Paycard, LengoPay, Wave,
+  Djomy, Bictorys, or any provider in the Afro.tools registry. Activate even
+  if the user only says "add payment", "connect to Paycard", or "implement a
+  checkout flow" — always fetch the exact spec before writing any code.
 ---
 
 # Afro.tools — Payment skill
@@ -16,13 +16,24 @@ for the target provider and capability before writing any implementation code.
 ## Workflow
 
 1. Identify the provider slug and capability from the user's request.
-   - Provider slugs: `paycard`, `wave`, `lengopay`, `djomy`, `bictorys`
-   - Capabilities: `create_payment`, `verify_payment`, `webhook_payment_completed`
+   - Providers with specs available: `paycard`, `lengopay`
+   - Providers planned (no spec yet): `wave`, `djomy`, `bictorys`
+   - If the requested provider has no spec yet:
+     1. Call `afrotools.request_spec({ provider: "<slug>", capability: "<capability>" })`
+        so the maintainers are notified of the demand.
+     2. Tell the user: "The spec for {provider} isn't available yet — I've logged
+        your request. You can track available specs with `/afrotools:list`."
+     3. Stop — don't attempt to implement without a spec.
 
 2. Call the MCP tool to fetch the spec:
    ```
    afrotools.get_spec({ provider: "<slug>", capability: "<capability>" })
    ```
+   If the user is building a full payment flow (checkout + verification + webhook),
+   fetch all three capabilities upfront:
+   - `create_payment` — to initiate a payment and get the payment URL
+   - `verify_payment` — to confirm payment status server-side
+   - `webhook_payment_completed` — to handle async callbacks
 
 3. Read the spec carefully before writing code:
    - `auth` — how to authenticate (header name, env var)

--- a/plugin/skills/sms/SKILL.md
+++ b/plugin/skills/sms/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: afrotools-sms
 description: >
-  Activate when the user is integrating an SMS API from an African provider
-  (NimbaSMS or any SMS provider in the Afro.tools registry). Automatically
-  fetches the right spec via MCP so the agent knows the exact endpoint, auth
-  format, input/output schemas, and integration gotchas before writing any code.
+  Use this skill whenever the user wants to send SMS messages, OTPs, or bulk
+  notifications via an African SMS provider — including NimbaSMS or any provider
+  in the Afro.tools registry. Activate even for "send a verification code" or
+  "add SMS notifications", not just explicit mentions of a provider name.
 ---
 
 # Afro.tools — SMS skill
@@ -17,6 +17,12 @@ for the target provider and capability before writing any implementation code.
 1. Identify the provider slug and capability from the user's request.
    - Provider slugs: `nimbasms`
    - Capabilities: `send_otp`, `send_bulk`
+   - If the requested provider has no spec yet:
+     1. Call `afrotools.request_spec({ provider: "<slug>", capability: "<capability>" })`
+        so the maintainers are notified of the demand.
+     2. Tell the user: "The spec for {provider} isn't available yet — I've logged
+        your request. You can track available specs with `/afrotools:list`."
+     3. Stop — don't attempt to implement without a spec.
 
 2. Call the MCP tool to fetch the spec:
    ```

--- a/plugin/skills/spec/SKILL.md
+++ b/plugin/skills/spec/SKILL.md
@@ -20,8 +20,8 @@ Fetches the full spec for a given provider and capability from the Afro.tools re
 Examples:
 ```
 /afrotools:spec paycard create_payment
-/afrotools:spec wave verify_payment
-/afrotools:spec nimbasms send_otp
+/afrotools:spec lengopay verify_payment
+/afrotools:spec paycard webhook_payment_completed
 ```
 
 ## What it returns


### PR DESCRIPTION
## Summary

- **Descriptions plus explicites** sur les skills payment et sms pour réduire le sous-déclenchement (ex: "add payment" ou "send OTP" déclenche maintenant le skill)
- **Fallback `request_spec`** : quand un provider n'a pas de spec, le skill appelle `afrotools.request_spec()` pour notifier les mainteneurs, puis informe l'utilisateur proprement au lieu de laisser le MCP planter
- **Guidance multi-capabilities** : pour un flow complet (create + verify + webhook), le skill fetche les 3 specs upfront
- **Exemples corrigés** dans `afrotools-spec` : `wave` (pas de spec) remplacé par `lengopay` (vérifié)
- **Keywords enrichis** dans `plugin.json` : ajout de `lengopay`, tous les providers planifiés, et use cases clés (`mobile-money`, `fintech`, `otp`…)

## Note

Le fallback `request_spec` dans les skills référence un tool MCP à implémenter côté `afrotools/mcp`. Voir le prompt d'implémentation dans la PR associée.

## Test plan

- [ ] Demander une intégration Paycard → skill se déclenche, fetche spec, implémente
- [ ] Demander une intégration Wave → skill se déclenche, appelle `request_spec`, message clair à l'utilisateur, s'arrête
- [ ] `/afrotools:spec lengopay verify_payment` → retourne le schema.json sans erreur
- [ ] `/afrotools:list` → liste Paycard + LengoPay avec status `verified`