### PR TITLE
feat(plugin): add afrotools-debug and afrotools-new skills

### DIFF
--- a/plugin/skills/debug/SKILL.md
+++ b/plugin/skills/debug/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: afrotools-debug
+description: >
+  Use this skill when the user has a failing or broken Afro.tools integration —
+  wrong status codes, auth errors, webhook not firing, unexpected response fields,
+  or any runtime error from a Paycard, LengoPay, NimbaSMS, or other Afro.tools
+  provider. Activate even if the user just pastes an error without context.
+---
+
+# Afro.tools — Debug skill
+
+When this skill activates, fetch the spec for the affected provider and capability,
+then systematically compare it against the user's implementation to find the gap.
+
+## Workflow
+
+1. Identify the provider slug and capability from the error, code snippet, or user
+   description. Ask if unclear — don't guess.
+
+2. Fetch the spec:
+   ```
+   afrotools.get_spec({ provider: "<slug>", capability: "<capability>" })
+   ```
+
+3. **Check gotchas first.** Most integration failures map directly to a documented
+   gotcha. Read every entry before looking elsewhere.
+
+4. Cross-check the implementation against the spec:
+   - **Auth** — correct field name, location (header vs body), format string
+   - **Endpoint** — correct method and URL, path params in the right place
+   - **Field names** — provider fields are often non-standard (e.g. `paycard-amount`,
+     not `amount`); compare the user's payload against `input_schema`
+   - **Status values** — enums are case-sensitive (e.g. LengoPay uses `SUCCESS`,
+     not `success`); `code: 0` on Paycard means "found", not "paid"
+   - **Webhook** — returning HTTP 200 immediately, not fulfilling on callback alone,
+     HTTPS required for some providers
+
+5. Surface the diagnosis clearly:
+   - Quote the relevant spec field or gotcha
+   - Show what the code does vs. what the spec requires
+   - Provide a minimal corrected snippet

--- a/plugin/skills/debug/SKILL.md
+++ b/plugin/skills/debug/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: afrotools-debug
+name: debug
 description: >
   Use this skill when the user has a failing or broken Afro.tools integration —
   wrong status codes, auth errors, webhook not firing, unexpected response fields,

--- a/plugin/skills/list/SKILL.md
+++ b/plugin/skills/list/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: afrotools-list
+name: list
 description: >
   List all available specs in the Afro.tools registry, optionally filtered by
   category or provider. Manual invocation only.

--- a/plugin/skills/new/SKILL.md
+++ b/plugin/skills/new/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: afrotools-new
+description: >
+  Scaffold a new ATSS spec (schema.json + canonical_example.ts) for a provider
+  and capability. Manual invocation only.
+disable-model-invocation: true
+---
+
+# /afrotools:new
+
+Scaffolds a new spec folder for a provider and capability, pre-filled with the
+correct ATSS structure and ready to complete.
+
+## Usage
+
+```
+/afrotools:new <category> <provider_slug> <capability>
+```
+
+Examples:
+```
+/afrotools:new payment wave create_payment
+/afrotools:new sms mynewprovider send_otp
+```
+
+## Workflow
+
+1. Parse the three arguments: `category`, `provider_slug`, `capability`.
+
+2. Read `schema.template.json` and `specs/CLAUDE.md` to get the exact field rules
+   and canonical_example.ts format before generating anything.
+
+3. Create the folder `specs/{category}/{provider_slug}/{capability}/`.
+
+4. Generate `schema.json` with all required ATSS fields:
+   - Set `status` to `"draft"` — never `compliant` or `verified`
+   - Fill known fields from the arguments (`category`, `capability`, `provider_slug`)
+   - Leave unknown fields (endpoint URL, auth format, schemas) as `"TODO"` strings
+     so the contributor knows exactly what to complete
+
+5. Generate `canonical_example.ts` with the correct structure:
+   - JSDoc header (`@provider`, `@capability`, `@atss`, `@capability_type`)
+   - Env var check at the top
+   - TypeScript interfaces for input, response, and error
+   - Main function using native `fetch` only — no npm imports
+   - Usage example in a comment block
+
+6. Run `npm run validate` and show the output.
+
+7. List the fields the contributor still needs to fill in before the spec can
+   reach `compliant` status.
+
+## Rules
+
+- `status` stays `"draft"` until `npm run validate` passes with zero errors
+- Native fetch only in `canonical_example.ts` — no axios, no node-fetch, no imports
+- Never add a `package.json` inside the spec folder

--- a/plugin/skills/new/SKILL.md
+++ b/plugin/skills/new/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: afrotools-new
+name: new
 description: >
   Scaffold a new ATSS spec (schema.json + canonical_example.ts) for a provider
   and capability. Manual invocation only.

--- a/plugin/skills/payment/SKILL.md
+++ b/plugin/skills/payment/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: afrotools-payment
+name: payment
 description: >
   Use this skill whenever the user wants to integrate, implement, or test a
   payment API from an African provider — including Paycard, LengoPay, Wave,

--- a/plugin/skills/sms/SKILL.md
+++ b/plugin/skills/sms/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: afrotools-sms
+name: sms
 description: >
   Use this skill whenever the user wants to send SMS messages, OTPs, or bulk
   notifications via an African SMS provider — including NimbaSMS or any provider

--- a/plugin/skills/spec/SKILL.md
+++ b/plugin/skills/spec/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: afrotools-spec
+name: spec
 description: >
   Fetch and display the full ATSS spec for a specific provider and capability.
   Use this to inspect a spec before implementing, review field rules, or check


### PR DESCRIPTION
## Summary

- **`afrotools-debug`** (auto) : nouveau skill déclenché quand une intégration Afro.tools plante. Fetche le spec du provider concerné, vérifie les gotchas en premier, puis croise l'implémentation avec l'auth, l'endpoint, les noms de champs et les valeurs d'enum.
- **`/afrotools:new`** (manuel) : scaffold d'un nouveau spec ATSS pour les contributeurs. Génère `schema.json` + `canonical_example.ts` pré-remplis et lance `npm run validate`.
- **Fix** : tous les `name` dans les frontmatters des skills alignés avec leur nom de dossier (le plugin préfixe automatiquement avec `afrotools:`).

## Test plan

- [ ] Coller une erreur d'intégration Paycard → `afrotools-debug` se déclenche, fetche le spec, identifie le problème via les gotchas
- [ ] `/afrotools:new payment wave create_payment` → crée le dossier + fichiers, lance la validation, liste les champs à compléter
- [ ] Vérifier que les warnings de linter sur les `name` des skills ont disparu