### PR TITLE
feat(wave): add 7 payment capabilities

### DIFF
--- a/specs/payment/wave/create_checkout_session/canonical_example.ts
+++ b/specs/payment/wave/create_checkout_session/canonical_example.ts
@@ -1,0 +1,78 @@
+/**
+ * @provider Wave
+ * @capability create_checkout_session
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface CreateCheckoutSessionInput {
+  amount: string;
+  currency: string;
+  error_url: string;
+  success_url: string;
+  client_reference?: string;
+  restrict_payer_mobile?: string;
+}
+
+interface CreateCheckoutSessionResponse {
+  id: string;
+  wave_launch_url: string;
+  checkout_status: "open" | "complete" | "expired";
+  payment_status: "processing" | "cancelled" | "succeeded";
+  amount: string;
+  currency: string;
+  client_reference?: string;
+  business_name: string;
+  transaction_id?: string;
+  when_created: string;
+  when_expires: string;
+  when_completed?: string;
+  last_payment_error?: { code: string; message: string };
+}
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function createCheckoutSession(
+  input: CreateCheckoutSessionInput
+): Promise<CreateCheckoutSessionResponse> {
+  const response = await fetch("https://api.wave.com/v1/checkout/sessions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${WAVE_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  return response.json() as Promise<CreateCheckoutSessionResponse>;
+}
+
+/*
+Usage example:
+
+const session = await createCheckoutSession({
+  amount: "5000",        // string, pas un nombre — XOF sans décimales
+  currency: "XOF",
+  success_url: "https://myapp.com/payment/success",
+  error_url: "https://myapp.com/payment/error",
+  client_reference: "order_123",
+});
+
+// Stocker session.id en base AVANT de rediriger.
+// C'est le seul moyen de vérifier le paiement côté serveur.
+await db.orders.update({ id: "order_123" }, { wave_session_id: session.id });
+
+// Rediriger l'utilisateur vers Wave (navigateur natif, pas de WebView)
+// res.redirect(session.wave_launch_url);
+*/

--- a/specs/payment/wave/create_checkout_session/canonical_example.ts
+++ b/specs/payment/wave/create_checkout_session/canonical_example.ts
@@ -15,6 +15,7 @@ interface CreateCheckoutSessionInput {
   success_url: string;
   client_reference?: string;
   restrict_payer_mobile?: string;
+  aggregated_merchant_id?: string;
 }
 
 interface CreateCheckoutSessionResponse {
@@ -27,6 +28,10 @@ interface CreateCheckoutSessionResponse {
   client_reference?: string;
   business_name: string;
   transaction_id?: string;
+  success_url: string;
+  error_url: string;
+  restrict_payer_mobile?: string;
+  aggregated_merchant_id?: string;
   when_created: string;
   when_expires: string;
   when_completed?: string;

--- a/specs/payment/wave/create_checkout_session/schema.json
+++ b/specs/payment/wave/create_checkout_session/schema.json
@@ -7,8 +7,18 @@
   "capability": "create_checkout_session",
   "capability_type": "synchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/checkout",
   "docs_public": true,
@@ -25,7 +35,12 @@
   },
   "input_schema": {
     "type": "object",
-    "required": ["amount", "currency", "error_url", "success_url"],
+    "required": [
+      "amount",
+      "currency",
+      "error_url",
+      "success_url"
+    ],
     "properties": {
       "amount": {
         "type": "string",
@@ -73,12 +88,21 @@
       },
       "checkout_status": {
         "type": "string",
-        "enum": ["open", "complete", "expired"],
-        "description": "État de la session de checkout."
+        "enum": [
+          "open",
+          "complete",
+          "expired",
+          "failed"
+        ],
+        "description": "État de la session de checkout. 'failed' peut apparaître dans le contexte de l'événement webhook checkout.session.payment_failed."
       },
       "payment_status": {
         "type": "string",
-        "enum": ["processing", "cancelled", "succeeded"],
+        "enum": [
+          "processing",
+          "cancelled",
+          "succeeded"
+        ],
         "description": "État du paiement associé."
       },
       "amount": {
@@ -138,8 +162,12 @@
         "type": "object",
         "description": "Dernière erreur de paiement. Présent uniquement si payment_status est processing ou cancelled.",
         "properties": {
-          "code": { "type": "string" },
-          "message": { "type": "string" }
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     }
@@ -154,6 +182,24 @@
       "message": {
         "type": "string",
         "description": "Description lisible de l'erreur."
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
       }
     }
   },

--- a/specs/payment/wave/create_checkout_session/schema.json
+++ b/specs/payment/wave/create_checkout_session/schema.json
@@ -1,0 +1,150 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "create_checkout_session",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/checkout",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.wave.com/v1/checkout/sessions"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["amount", "currency", "error_url", "success_url"],
+    "properties": {
+      "amount": {
+        "type": "string",
+        "description": "Montant à collecter, en string. 0 à 2 décimales selon la devise. XOF n'accepte pas de décimales. Ex: \"5000\" ou \"1500.50\"."
+      },
+      "currency": {
+        "type": "string",
+        "description": "Code ISO 4217 en majuscules. Ex: \"XOF\", \"GNF\", \"UGX\"."
+      },
+      "error_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL HTTPS vers laquelle Wave redirige l'utilisateur en cas d'échec ou d'annulation du paiement."
+      },
+      "success_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL HTTPS vers laquelle Wave redirige l'utilisateur après un paiement réussi."
+      },
+      "client_reference": {
+        "type": "string",
+        "description": "Référence interne (max 255 chars) pour corréler la session avec votre système. Renvoyée dans la réponse et les webhooks."
+      },
+      "restrict_payer_mobile": {
+        "type": "string",
+        "description": "Numéro E.164 (ex: \"+221700000000\"). Si présent, seul ce compte Wave peut payer cette session."
+      },
+      "aggregated_merchant_id": {
+        "type": "string",
+        "description": "ID de marchand agrégé. Uniquement pour les plateformes ayant activé l'API Aggregated Merchants."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifiant unique de la session (préfixe \"cos-\", max 20 chars). Stocker avant de rediriger — requis pour verify_payment."
+      },
+      "wave_launch_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL à ouvrir dans le navigateur pour lancer le paiement Wave. Ne pas ouvrir dans une WebView."
+      },
+      "checkout_status": {
+        "type": "string",
+        "enum": ["open", "complete", "expired"],
+        "description": "État de la session de checkout."
+      },
+      "payment_status": {
+        "type": "string",
+        "enum": ["processing", "cancelled", "succeeded"],
+        "description": "État du paiement associé."
+      },
+      "amount": {
+        "type": "string",
+        "description": "Montant demandé."
+      },
+      "currency": {
+        "type": "string",
+        "description": "Code ISO 4217."
+      },
+      "client_reference": {
+        "type": "string",
+        "description": "Référence interne fournie à la création."
+      },
+      "business_name": {
+        "type": "string",
+        "description": "Nom du business affiché au payeur."
+      },
+      "transaction_id": {
+        "type": "string",
+        "description": "Identifiant de transaction Wave (visible dans l'app utilisateur). Absent si le paiement n'est pas encore complété."
+      },
+      "when_created": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Horodatage ISO 8601 UTC de création."
+      },
+      "when_expires": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Horodatage ISO 8601 UTC d'expiration. Par défaut : 30 minutes après création."
+      },
+      "when_completed": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Horodatage ISO 8601 UTC de complétion ou d'expiration. Absent si la session est encore ouverte."
+      },
+      "last_payment_error": {
+        "type": "object",
+        "description": "Dernière erreur de paiement. Présent uniquement si payment_status est processing ou cancelled.",
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "string",
+        "description": "Code d'erreur. Ex: request-validation-error, unauthorized-wallet, service-unavailable."
+      },
+      "message": {
+        "type": "string",
+        "description": "Description lisible de l'erreur."
+      }
+    }
+  },
+  "gotchas": [
+    "Stocker session.id immédiatement avant de rediriger l'utilisateur — c'est le seul identifiant pour appeler verify_payment côté serveur.",
+    "wave_launch_url doit être ouvert directement dans le navigateur de l'utilisateur. Ne jamais l'ouvrir dans une WebView ou un iframe — le paiement ne s'initiera pas correctement.",
+    "La session expire par défaut 30 minutes après création. Après expiration, checkout_status passe à 'expired' et le paiement est impossible.",
+    "amount est une string, pas un nombre. XOF n'accepte aucune décimale — envoyer \"5000\" et non \"5000.00\" ou 5000.",
+    "La clé API est liée à un seul wallet Wave. Pour opérer dans plusieurs pays, obtenir une clé par wallet.",
+    "Il n'y a pas d'environnement sandbox. Tous les appels touchent la production."
+  ]
+}

--- a/specs/payment/wave/create_checkout_session/schema.json
+++ b/specs/payment/wave/create_checkout_session/schema.json
@@ -116,6 +116,24 @@
         "format": "date-time",
         "description": "Horodatage ISO 8601 UTC de complétion ou d'expiration. Absent si la session est encore ouverte."
       },
+      "success_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL de redirection post-paiement réussi, telle que fournie à la création."
+      },
+      "error_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL de redirection en cas d'échec, telle que fournie à la création."
+      },
+      "restrict_payer_mobile": {
+        "type": "string",
+        "description": "Numéro E.164 de restriction si fourni à la création."
+      },
+      "aggregated_merchant_id": {
+        "type": "string",
+        "description": "ID de marchand agrégé utilisé pour cette session."
+      },
       "last_payment_error": {
         "type": "object",
         "description": "Dernière erreur de paiement. Présent uniquement si payment_status est processing ou cancelled.",

--- a/specs/payment/wave/create_payout_batch/canonical_example.ts
+++ b/specs/payment/wave/create_payout_batch/canonical_example.ts
@@ -5,6 +5,8 @@
  * @capability_type asynchronous
  */
 
+import { randomUUID } from "crypto";
+
 const WAVE_API_KEY = process.env.WAVE_API_KEY;
 if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
 
@@ -46,13 +48,15 @@ interface WaveError {
 }
 
 export async function createPayoutBatch(
-  payouts: PayoutItem[]
+  payouts: PayoutItem[],
+  idempotencyKey: string = randomUUID()
 ): Promise<CreatePayoutBatchResponse> {
   const response = await fetch("https://api.wave.com/v1/payout-batch", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${WAVE_API_KEY}`,
       "Content-Type": "application/json",
+      "Idempotency-Key": idempotencyKey,
     },
     body: JSON.stringify({ payouts }),
   });

--- a/specs/payment/wave/create_payout_batch/canonical_example.ts
+++ b/specs/payment/wave/create_payout_batch/canonical_example.ts
@@ -1,0 +1,116 @@
+/**
+ * @provider Wave
+ * @capability create_payout_batch
+ * @atss 1.0
+ * @capability_type asynchronous
+ */
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface PayoutItem {
+  currency: string;
+  receive_amount: string;
+  mobile: string;
+  name?: string;
+  national_id?: string;
+  client_reference?: string;
+  payment_reason?: string;
+  aggregated_merchant_id?: string;
+}
+
+interface CreatePayoutBatchResponse {
+  id: string;
+}
+
+interface PayoutBatchStatus {
+  id: string;
+  status: "processing" | "complete";
+  payouts: Array<{
+    id: string;
+    status: "processing" | "succeeded" | "failed" | "reversed";
+    currency: string;
+    receive_amount: string;
+    fee: string;
+    mobile: string;
+    name?: string;
+    client_reference?: string;
+    timestamp: string;
+    payout_error?: { error_code: string; error_message?: string };
+  }>;
+}
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function createPayoutBatch(
+  payouts: PayoutItem[]
+): Promise<CreatePayoutBatchResponse> {
+  const response = await fetch("https://api.wave.com/v1/payout-batch", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${WAVE_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ payouts }),
+  });
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  return response.json() as Promise<CreatePayoutBatchResponse>;
+}
+
+export async function getPayoutBatch(batchId: string): Promise<PayoutBatchStatus> {
+  const response = await fetch(
+    `https://api.wave.com/v1/payout-batch/${batchId}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${WAVE_API_KEY}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  return response.json() as Promise<PayoutBatchStatus>;
+}
+
+/*
+Usage example — envoi de payroll :
+
+// 1. Créer le batch
+const batch = await createPayoutBatch([
+  { currency: "XOF", receive_amount: "150000", mobile: "+221700000001", name: "Mamadou Diallo", client_reference: "payroll_2024_01_emp_1" },
+  { currency: "XOF", receive_amount: "200000", mobile: "+221700000002", name: "Fatoumata Bah",  client_reference: "payroll_2024_01_emp_2" },
+  { currency: "XOF", receive_amount: "175000", mobile: "+221700000003", name: "Ibrahima Sow",   client_reference: "payroll_2024_01_emp_3" },
+]);
+
+// 2. Stocker le batch.id et attendre le traitement
+await db.payrollBatches.create({ wave_batch_id: batch.id, status: "processing" });
+
+// 3. Interroger jusqu'à complétion (via job, webhook, ou polling manuel)
+let result: PayoutBatchStatus;
+do {
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  result = await getPayoutBatch(batch.id);
+} while (result.status === "processing");
+
+// 4. Vérifier chaque payout individuellement — 'complete' ≠ tout réussi
+for (const payout of result.payouts) {
+  if (payout.status === "succeeded") {
+    await db.payroll.update({ client_reference: payout.client_reference }, { status: "paid" });
+  } else if (payout.status === "failed") {
+    console.error(`Payout échoué pour ${payout.mobile} :`, payout.payout_error?.error_code);
+    await db.payroll.update({ client_reference: payout.client_reference }, { status: "failed" });
+  }
+}
+*/

--- a/specs/payment/wave/create_payout_batch/schema.json
+++ b/specs/payment/wave/create_payout_batch/schema.json
@@ -7,8 +7,18 @@
   "capability": "create_payout_batch",
   "capability_type": "asynchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/payout",
   "docs_public": true,
@@ -25,14 +35,20 @@
   },
   "input_schema": {
     "type": "object",
-    "required": ["payouts"],
+    "required": [
+      "payouts"
+    ],
     "properties": {
       "payouts": {
         "type": "array",
         "description": "Liste de payouts à envoyer en une seule requête.",
         "items": {
           "type": "object",
-          "required": ["currency", "receive_amount", "mobile"],
+          "required": [
+            "currency",
+            "receive_amount",
+            "mobile"
+          ],
           "properties": {
             "currency": {
               "type": "string",
@@ -76,18 +92,41 @@
     "properties": {
       "id": {
         "type": "string",
-        "description": "Identifiant unique du batch. Utiliser pour interroger GET /v1/payout-batch/{id} jusqu'à ce que status soit 'complete'."
+        "description": "Identifiant unique du batch (préfixe \"pb-\"). Utiliser pour interroger GET /v1/payout-batch/{id} jusqu'à ce que status soit 'complete'."
       }
     }
   },
   "error_schema": {
     "type": "object",
     "properties": {
-      "code": { "type": "string" },
-      "message": { "type": "string" }
+      "code": {
+        "type": "string"
+      },
+      "message": {
+        "type": "string"
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   },
   "gotchas": [
+    "Chaque requête POST /v1/payout-batch doit inclure un header Idempotency-Key unique (UUID v4 recommandé, max 255 chars). Un batch peut distribuer des fonds à des dizaines de destinataires — un retry sans idempotency key peut déclencher tous les payouts en double.",
     "Cet endpoint est asynchrone — il retourne immédiatement un batch.id sans attendre le traitement des payouts. Interroger GET /v1/payout-batch/{id} en polling jusqu'à status === 'complete'.",
     "batch.status === 'complete' ne signifie pas que tous les payouts ont réussi. Inspecter le status de chaque payout individuel dans la réponse — certains peuvent être 'failed' pendant que d'autres sont 'succeeded'.",
     "Il n'y a pas de status 'success' ou 'failed' au niveau du batch lui-même, seulement 'processing' et 'complete'. Le résultat réel est dans chaque payout.",

--- a/specs/payment/wave/create_payout_batch/schema.json
+++ b/specs/payment/wave/create_payout_batch/schema.json
@@ -1,0 +1,96 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "create_payout_batch",
+  "capability_type": "asynchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/payout",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.wave.com/v1/payout-batch"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["payouts"],
+    "properties": {
+      "payouts": {
+        "type": "array",
+        "description": "Liste de payouts à envoyer en une seule requête.",
+        "items": {
+          "type": "object",
+          "required": ["currency", "receive_amount", "mobile"],
+          "properties": {
+            "currency": {
+              "type": "string",
+              "description": "Code ISO 4217. Ex: \"XOF\"."
+            },
+            "receive_amount": {
+              "type": "string",
+              "description": "Montant que le destinataire reçoit, en string, sans décimales."
+            },
+            "mobile": {
+              "type": "string",
+              "description": "Numéro E.164 du destinataire. Ex: \"+221700000000\"."
+            },
+            "name": {
+              "type": "string",
+              "description": "Nom du destinataire (max 255 chars)."
+            },
+            "national_id": {
+              "type": "string",
+              "description": "Pièce d'identité nationale (max 255 chars)."
+            },
+            "client_reference": {
+              "type": "string",
+              "description": "Référence interne par payout (max 255 chars)."
+            },
+            "payment_reason": {
+              "type": "string",
+              "description": "Motif visible par le destinataire (max 40 chars)."
+            },
+            "aggregated_merchant_id": {
+              "type": "string",
+              "description": "ID de marchand agrégé si applicable."
+            }
+          }
+        }
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifiant unique du batch. Utiliser pour interroger GET /v1/payout-batch/{id} jusqu'à ce que status soit 'complete'."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": { "type": "string" },
+      "message": { "type": "string" }
+    }
+  },
+  "gotchas": [
+    "Cet endpoint est asynchrone — il retourne immédiatement un batch.id sans attendre le traitement des payouts. Interroger GET /v1/payout-batch/{id} en polling jusqu'à status === 'complete'.",
+    "batch.status === 'complete' ne signifie pas que tous les payouts ont réussi. Inspecter le status de chaque payout individuel dans la réponse — certains peuvent être 'failed' pendant que d'autres sont 'succeeded'.",
+    "Il n'y a pas de status 'success' ou 'failed' au niveau du batch lui-même, seulement 'processing' et 'complete'. Le résultat réel est dans chaque payout.",
+    "Chaque payout dans le batch est traité indépendamment. Un échec sur un payout (ex: insufficient-funds) n'annule pas les autres."
+  ]
+}

--- a/specs/payment/wave/expire_checkout/canonical_example.ts
+++ b/specs/payment/wave/expire_checkout/canonical_example.ts
@@ -1,0 +1,49 @@
+/**
+ * @provider Wave
+ * @capability expire_checkout
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function expireCheckout(sessionId: string): Promise<void> {
+  const response = await fetch(
+    `https://api.wave.com/v1/checkout/sessions/${sessionId}/expire`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${WAVE_API_KEY}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  // HTTP 200 avec corps vide — pas de valeur de retour
+}
+
+/*
+Usage example :
+
+// Cas d'usage typique : l'utilisateur annule sa commande avant de payer
+await expireCheckout("cos-abc123");
+
+// Attention : retourne HTTP 409 si la session est déjà complétée ou expirée.
+// Vérifier le statut via verify_payment si vous n'êtes pas sûr du statut courant.
+try {
+  await expireCheckout("cos-abc123");
+} catch (err) {
+  // 409 = déjà complétée ou expirée — ignorer silencieusement si c'est attendu
+  if (!(err instanceof Error) || !err.message.includes("409")) throw err;
+}
+*/

--- a/specs/payment/wave/expire_checkout/schema.json
+++ b/specs/payment/wave/expire_checkout/schema.json
@@ -1,0 +1,57 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "expire_checkout",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/checkout",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.wave.com/v1/checkout/sessions/{id}/expire"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifiant de la session checkout à expirer (préfixe \"cos-\")."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "description": "HTTP 200 avec corps vide en cas de succès."
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "string",
+        "description": "Code d'erreur. Ex: checkout-session-not-found (404), 409 si déjà complétée ou expirée."
+      },
+      "message": {
+        "type": "string",
+        "description": "Description lisible de l'erreur."
+      }
+    }
+  },
+  "gotchas": [
+    "Impossible d'expirer une session déjà complétée ou déjà expirée — Wave retourne HTTP 409.",
+    "Les sessions expirent automatiquement 30 minutes après création. Cet endpoint est utile pour libérer immédiatement le stock réservé sans attendre l'expiration naturelle."
+  ]
+}

--- a/specs/payment/wave/expire_checkout/schema.json
+++ b/specs/payment/wave/expire_checkout/schema.json
@@ -7,8 +7,18 @@
   "capability": "expire_checkout",
   "capability_type": "synchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/checkout",
   "docs_public": true,
@@ -25,7 +35,9 @@
   },
   "input_schema": {
     "type": "object",
-    "required": ["id"],
+    "required": [
+      "id"
+    ],
     "properties": {
       "id": {
         "type": "string",
@@ -47,6 +59,24 @@
       "message": {
         "type": "string",
         "description": "Description lisible de l'erreur."
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
       }
     }
   },

--- a/specs/payment/wave/get_balance/canonical_example.ts
+++ b/specs/payment/wave/get_balance/canonical_example.ts
@@ -1,0 +1,57 @@
+/**
+ * @provider Wave
+ * @capability get_balance
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface BalanceResponse {
+  amount: string;
+  currency: string;
+}
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function getBalance(
+  includeSubaccounts?: boolean
+): Promise<BalanceResponse> {
+  const url = new URL("https://api.wave.com/v1/balance");
+  if (includeSubaccounts) url.searchParams.set("include_subaccounts", "true");
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${WAVE_API_KEY}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  return response.json() as Promise<BalanceResponse>;
+}
+
+/*
+Usage example :
+
+const balance = await getBalance();
+console.log(`Solde : ${balance.amount} ${balance.currency}`);
+// "Solde : 125000 XOF"
+
+// amount est une string — parser avant comparaison
+const amount = parseFloat(balance.amount);
+if (amount < 10000) {
+  console.warn("Solde insuffisant pour des payouts");
+}
+
+// Pour un wallet multi-pays, appeler avec des clés API différentes par pays
+// (chaque clé est liée à un seul wallet)
+*/

--- a/specs/payment/wave/get_balance/schema.json
+++ b/specs/payment/wave/get_balance/schema.json
@@ -7,8 +7,18 @@
   "capability": "get_balance",
   "capability_type": "synchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/balance-api",
   "docs_public": true,
@@ -55,6 +65,24 @@
       "message": {
         "type": "string",
         "description": "Description lisible de l'erreur."
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
       }
     }
   },

--- a/specs/payment/wave/get_balance/schema.json
+++ b/specs/payment/wave/get_balance/schema.json
@@ -1,0 +1,65 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "get_balance",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/balance-api",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.wave.com/v1/balance"
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "include_subaccounts": {
+        "type": "boolean",
+        "description": "Si true, inclut les soldes des sous-comptes dans le total retourné."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "amount": {
+        "type": "string",
+        "description": "Solde actuel du wallet en string. Peut être négatif si le wallet est en débit."
+      },
+      "currency": {
+        "type": "string",
+        "description": "Code ISO 4217 du wallet. Ex: \"XOF\"."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "string",
+        "description": "Code d'erreur. Ex: unauthorized-wallet, disabled-wallet."
+      },
+      "message": {
+        "type": "string",
+        "description": "Description lisible de l'erreur."
+      }
+    }
+  },
+  "gotchas": [
+    "La clé API est liée à un seul wallet. Pour consulter le solde de plusieurs wallets (multi-pays), obtenir une clé API par wallet et appeler cet endpoint une fois par clé.",
+    "amount est retourné en string et peut être négatif en cas de débit. Toujours parser en nombre avant d'effectuer des comparaisons."
+  ]
+}

--- a/specs/payment/wave/get_payout/canonical_example.ts
+++ b/specs/payment/wave/get_payout/canonical_example.ts
@@ -1,0 +1,75 @@
+/**
+ * @provider Wave
+ * @capability get_payout
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface PayoutResponse {
+  id: string;
+  status: "processing" | "succeeded" | "failed" | "reversed";
+  currency: string;
+  receive_amount: string;
+  fee: string;
+  mobile: string;
+  name?: string;
+  national_id?: string;
+  client_reference?: string;
+  payment_reason?: string;
+  aggregated_merchant_id?: string;
+  timestamp: string;
+  payout_error?: { error_code: string; error_message?: string };
+}
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function getPayout(payoutId: string): Promise<PayoutResponse> {
+  const response = await fetch(
+    `https://api.wave.com/v1/payout/${payoutId}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${WAVE_API_KEY}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  return response.json() as Promise<PayoutResponse>;
+}
+
+/*
+Usage example — polling d'un payout en status 'processing' :
+
+async function waitForPayout(payoutId: string, maxAttempts = 10): Promise<PayoutResponse> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const payout = await getPayout(payoutId);
+
+    if (payout.status === "succeeded" || payout.status === "failed" || payout.status === "reversed") {
+      return payout;
+    }
+
+    // Attendre avant de re-interroger (backoff simple)
+    await new Promise((resolve) => setTimeout(resolve, 2000 * (i + 1)));
+  }
+
+  throw new Error(`Payout ${payoutId} toujours en 'processing' après ${maxAttempts} tentatives`);
+}
+
+const payout = await waitForPayout("payout-abc123");
+if (payout.status === "succeeded") {
+  await db.payouts.update({ id: payout.id }, { status: "succeeded" });
+} else if (payout.status === "failed") {
+  console.error("Payout échoué :", payout.payout_error?.error_code);
+}
+*/

--- a/specs/payment/wave/get_payout/schema.json
+++ b/specs/payment/wave/get_payout/schema.json
@@ -1,0 +1,113 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "get_payout",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/payout",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.wave.com/v1/payout/{id}"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifiant du payout retourné par send_payout."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifiant unique du payout."
+      },
+      "status": {
+        "type": "string",
+        "enum": ["processing", "succeeded", "failed", "reversed"],
+        "description": "État courant du payout."
+      },
+      "currency": {
+        "type": "string",
+        "description": "Code ISO 4217."
+      },
+      "receive_amount": {
+        "type": "string",
+        "description": "Montant reçu par le destinataire."
+      },
+      "fee": {
+        "type": "string",
+        "description": "Frais prélevés sur le wallet."
+      },
+      "mobile": {
+        "type": "string",
+        "description": "Numéro E.164 du destinataire."
+      },
+      "name": {
+        "type": "string",
+        "description": "Nom du destinataire si fourni."
+      },
+      "national_id": {
+        "type": "string",
+        "description": "Pièce d'identité si fournie."
+      },
+      "client_reference": {
+        "type": "string",
+        "description": "Référence interne si fournie."
+      },
+      "payment_reason": {
+        "type": "string",
+        "description": "Motif du paiement si fourni."
+      },
+      "aggregated_merchant_id": {
+        "type": "string",
+        "description": "ID de marchand agrégé si applicable."
+      },
+      "timestamp": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Horodatage ISO 8601 UTC du payout."
+      },
+      "payout_error": {
+        "type": "object",
+        "description": "Présent uniquement si status est 'failed'.",
+        "properties": {
+          "error_code": { "type": "string" },
+          "error_message": { "type": "string" }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "string",
+        "description": "Code d'erreur. Ex: not-found (404)."
+      },
+      "message": { "type": "string" }
+    }
+  },
+  "gotchas": [
+    "Utiliser cet endpoint pour surveiller un payout en status 'processing' retourné par send_payout. Un payout 'processing' peut encore basculer vers 'succeeded' ou 'failed' — ne jamais le marquer définitivement échoué avant d'avoir observé un status final.",
+    "Un payout en status 'reversed' a été annulé via POST /v1/payout/{id}/reverse. Le montant + les frais sont recrédités sur le wallet expéditeur."
+  ]
+}

--- a/specs/payment/wave/get_payout/schema.json
+++ b/specs/payment/wave/get_payout/schema.json
@@ -7,8 +7,18 @@
   "capability": "get_payout",
   "capability_type": "synchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/payout",
   "docs_public": true,
@@ -25,7 +35,9 @@
   },
   "input_schema": {
     "type": "object",
-    "required": ["id"],
+    "required": [
+      "id"
+    ],
     "properties": {
       "id": {
         "type": "string",
@@ -38,11 +50,16 @@
     "properties": {
       "id": {
         "type": "string",
-        "description": "Identifiant unique du payout."
+        "description": "Identifiant unique du payout (préfixe \"pt-\", max 20 chars)."
       },
       "status": {
         "type": "string",
-        "enum": ["processing", "succeeded", "failed", "reversed"],
+        "enum": [
+          "processing",
+          "succeeded",
+          "failed",
+          "reversed"
+        ],
         "description": "État courant du payout."
       },
       "currency": {
@@ -90,8 +107,12 @@
         "type": "object",
         "description": "Présent uniquement si status est 'failed'.",
         "properties": {
-          "error_code": { "type": "string" },
-          "error_message": { "type": "string" }
+          "error_code": {
+            "type": "string"
+          },
+          "error_message": {
+            "type": "string"
+          }
         }
       }
     }
@@ -103,7 +124,27 @@
         "type": "string",
         "description": "Code d'erreur. Ex: not-found (404)."
       },
-      "message": { "type": "string" }
+      "message": {
+        "type": "string"
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   },
   "gotchas": [

--- a/specs/payment/wave/get_transactions/canonical_example.ts
+++ b/specs/payment/wave/get_transactions/canonical_example.ts
@@ -37,6 +37,14 @@ interface Transaction {
   counterparty_mobile?: string;
   client_reference?: string;
   checkout_api_session_id?: string;
+  balance?: string;
+  counterparty_id?: string;
+  payment_reason?: string;
+  batch_id?: string;
+  aggregated_merchant_id?: string;
+  custom_fields?: Record<string, unknown>;
+  submerchant_id?: string;
+  government_tax_amount?: string;
 }
 
 interface TransactionsResponse {

--- a/specs/payment/wave/get_transactions/canonical_example.ts
+++ b/specs/payment/wave/get_transactions/canonical_example.ts
@@ -11,6 +11,7 @@ if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
 interface GetTransactionsInput {
   date?: string;
   after?: string;
+  first?: number;
   include_subaccounts?: boolean;
 }
 
@@ -45,6 +46,12 @@ interface Transaction {
   custom_fields?: Record<string, unknown>;
   submerchant_id?: string;
   government_tax_amount?: string;
+  government_tax_paid_by_wave?: string;
+  business_user_name?: string;
+  business_user_mobile?: string;
+  employee_id?: string;
+  aggregated_merchant_name?: string;
+  submerchant_name?: string;
 }
 
 interface TransactionsResponse {
@@ -68,6 +75,7 @@ export async function getTransactions(
   const url = new URL("https://api.wave.com/v1/transactions");
   if (input.date) url.searchParams.set("date", input.date);
   if (input.after) url.searchParams.set("after", input.after);
+  if (input.first) url.searchParams.set("first", String(input.first));
   if (input.include_subaccounts) url.searchParams.set("include_subaccounts", "true");
 
   const response = await fetch(url.toString(), {

--- a/specs/payment/wave/get_transactions/canonical_example.ts
+++ b/specs/payment/wave/get_transactions/canonical_example.ts
@@ -1,0 +1,110 @@
+/**
+ * @provider Wave
+ * @capability get_transactions
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface GetTransactionsInput {
+  date?: string;
+  after?: string;
+  include_subaccounts?: boolean;
+}
+
+interface Transaction {
+  timestamp: string;
+  transaction_id: string;
+  transaction_type:
+    | "merchant_payment"
+    | "merchant_payment_refund"
+    | "api_checkout"
+    | "api_checkout_refund"
+    | "api_payout"
+    | "api_payout_reversal"
+    | "bulk_payment"
+    | "bulk_payment_reversal"
+    | "b2b_payment"
+    | "b2b_payment_reversal"
+    | "merchant_sweep";
+  amount: string;
+  fee: string;
+  currency: string;
+  is_reversal: boolean;
+  counterparty_name?: string;
+  counterparty_mobile?: string;
+  client_reference?: string;
+  checkout_api_session_id?: string;
+}
+
+interface TransactionsResponse {
+  page_info: {
+    has_next_page: boolean;
+    end_cursor: string;
+    start_cursor: string | null;
+  };
+  date: string;
+  items: Transaction[];
+}
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function getTransactions(
+  input: GetTransactionsInput = {}
+): Promise<TransactionsResponse> {
+  const url = new URL("https://api.wave.com/v1/transactions");
+  if (input.date) url.searchParams.set("date", input.date);
+  if (input.after) url.searchParams.set("after", input.after);
+  if (input.include_subaccounts) url.searchParams.set("include_subaccounts", "true");
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${WAVE_API_KEY}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  return response.json() as Promise<TransactionsResponse>;
+}
+
+/** Récupère toutes les transactions d'un jour donné en gérant la pagination. */
+export async function getAllTransactionsForDate(date: string): Promise<Transaction[]> {
+  const all: Transaction[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const page = await getTransactions({ date, after: cursor });
+    all.push(...page.items);
+    cursor = page.page_info.has_next_page ? page.page_info.end_cursor : undefined;
+  } while (cursor);
+
+  return all;
+}
+
+/*
+Usage example :
+
+// Transactions du jour courant (UTC)
+const today = await getTransactions();
+console.log(`${today.items.length} transactions le ${today.date}`);
+
+// Toutes les transactions d'une date spécifique (avec pagination automatique)
+const transactions = await getAllTransactionsForDate("2024-03-15");
+
+// Filtrer uniquement les paiements checkout
+const checkouts = transactions.filter(t => t.transaction_type === "api_checkout");
+
+// Les transactions sont retournées de la plus ancienne à la plus récente.
+// Pour les plus récentes en premier :
+const recent = [...transactions].reverse();
+*/

--- a/specs/payment/wave/get_transactions/schema.json
+++ b/specs/payment/wave/get_transactions/schema.json
@@ -127,6 +127,39 @@
             "checkout_api_session_id": {
               "type": "string",
               "description": "ID de la session checkout associée (pour api_checkout)."
+            },
+            "balance": {
+              "type": "string",
+              "description": "Solde du wallet après cette transaction. Utile pour la réconciliation ligne à ligne."
+            },
+            "counterparty_id": {
+              "type": "string",
+              "description": "Identifiant de la contrepartie pour les paiements B2B."
+            },
+            "payment_reason": {
+              "type": "string",
+              "description": "Motif du paiement fourni par l'expéditeur."
+            },
+            "batch_id": {
+              "type": "string",
+              "description": "Identifiant du lot pour les paiements bulk."
+            },
+            "aggregated_merchant_id": {
+              "type": "string",
+              "description": "ID de marchand agrégé si applicable."
+            },
+            "custom_fields": {
+              "type": "object",
+              "description": "Métadonnées clé-valeur associées à la transaction.",
+              "additionalProperties": true
+            },
+            "submerchant_id": {
+              "type": "string",
+              "description": "Identifiant du sous-compte si include_subaccounts est activé."
+            },
+            "government_tax_amount": {
+              "type": "string",
+              "description": "Montant de taxe gouvernementale appliqué (Sénégal uniquement)."
             }
           }
         }

--- a/specs/payment/wave/get_transactions/schema.json
+++ b/specs/payment/wave/get_transactions/schema.json
@@ -7,8 +7,18 @@
   "capability": "get_transactions",
   "capability_type": "synchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/balance-api",
   "docs_public": true,
@@ -37,6 +47,10 @@
       "include_subaccounts": {
         "type": "boolean",
         "description": "Si true, inclut les transactions des sous-comptes."
+      },
+      "first": {
+        "type": "integer",
+        "description": "Nombre maximum de transactions à retourner par page. Si absent, Wave retourne la page complète."
       }
     }
   },
@@ -56,7 +70,10 @@
             "description": "Curseur à passer comme paramètre after pour obtenir la page suivante."
           },
           "start_cursor": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -160,6 +177,30 @@
             "government_tax_amount": {
               "type": "string",
               "description": "Montant de taxe gouvernementale appliqué (Sénégal uniquement)."
+            },
+            "government_tax_paid_by_wave": {
+              "type": "string",
+              "description": "Montant de taxe pris en charge par Wave (Sénégal uniquement)."
+            },
+            "business_user_name": {
+              "type": "string",
+              "description": "Nom de l'agent ou du dépositaire associé à la transaction."
+            },
+            "business_user_mobile": {
+              "type": "string",
+              "description": "Numéro de téléphone de l'agent ou du dépositaire."
+            },
+            "employee_id": {
+              "type": "string",
+              "description": "Identifiant employé associé à la transaction."
+            },
+            "aggregated_merchant_name": {
+              "type": "string",
+              "description": "Nom du marchand agrégé si applicable."
+            },
+            "submerchant_name": {
+              "type": "string",
+              "description": "Nom du sous-compte si include_subaccounts est activé."
             }
           }
         }
@@ -169,8 +210,30 @@
   "error_schema": {
     "type": "object",
     "properties": {
-      "code": { "type": "string" },
-      "message": { "type": "string" }
+      "code": {
+        "type": "string"
+      },
+      "message": {
+        "type": "string"
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   },
   "gotchas": [

--- a/specs/payment/wave/get_transactions/schema.json
+++ b/specs/payment/wave/get_transactions/schema.json
@@ -1,0 +1,149 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "get_transactions",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/balance-api",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.wave.com/v1/transactions"
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "date": {
+        "type": "string",
+        "description": "Date au format YYYY-MM-DD. Si absent, retourne les transactions du jour courant."
+      },
+      "after": {
+        "type": "string",
+        "description": "Curseur de pagination opaque. Passer la valeur end_cursor de la réponse précédente pour obtenir la page suivante."
+      },
+      "include_subaccounts": {
+        "type": "boolean",
+        "description": "Si true, inclut les transactions des sous-comptes."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "page_info": {
+        "type": "object",
+        "description": "Informations de pagination.",
+        "properties": {
+          "has_next_page": {
+            "type": "boolean",
+            "description": "true s'il reste des transactions à récupérer."
+          },
+          "end_cursor": {
+            "type": "string",
+            "description": "Curseur à passer comme paramètre after pour obtenir la page suivante."
+          },
+          "start_cursor": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "date": {
+        "type": "string",
+        "description": "Date des transactions retournées, au format YYYY-MM-DD."
+      },
+      "items": {
+        "type": "array",
+        "description": "Liste de transactions, triées de la plus ancienne à la plus récente.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Horodatage ISO 8601 UTC d'exécution de la transaction."
+            },
+            "transaction_id": {
+              "type": "string",
+              "description": "Identifiant unique de la transaction (max 20 chars)."
+            },
+            "transaction_type": {
+              "type": "string",
+              "enum": [
+                "merchant_payment",
+                "merchant_payment_refund",
+                "api_checkout",
+                "api_checkout_refund",
+                "api_payout",
+                "api_payout_reversal",
+                "bulk_payment",
+                "bulk_payment_reversal",
+                "b2b_payment",
+                "b2b_payment_reversal",
+                "merchant_sweep"
+              ],
+              "description": "Type de la transaction."
+            },
+            "amount": {
+              "type": "string",
+              "description": "Variation nette du solde (peut être négatif pour les débits)."
+            },
+            "fee": {
+              "type": "string",
+              "description": "Frais de la transaction."
+            },
+            "currency": {
+              "type": "string",
+              "description": "Code ISO 4217."
+            },
+            "is_reversal": {
+              "type": "boolean",
+              "description": "true si la transaction est un remboursement ou reversal."
+            },
+            "counterparty_name": {
+              "type": "string",
+              "description": "Nom de l'expéditeur ou du destinataire."
+            },
+            "counterparty_mobile": {
+              "type": "string",
+              "description": "Numéro de téléphone de la contrepartie."
+            },
+            "client_reference": {
+              "type": "string",
+              "description": "Référence interne fournie lors de la création du paiement."
+            },
+            "checkout_api_session_id": {
+              "type": "string",
+              "description": "ID de la session checkout associée (pour api_checkout)."
+            }
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": { "type": "string" },
+      "message": { "type": "string" }
+    }
+  },
+  "gotchas": [
+    "Les transactions sont retournées de la plus ancienne à la plus récente pour un jour donné. Pour récupérer les transactions les plus récentes en premier, il faut inverser le tableau côté client.",
+    "Sans paramètre date, Wave retourne uniquement les transactions du jour courant (UTC). Pour la réconciliation, toujours spécifier la date explicitement.",
+    "La pagination utilise des curseurs opaques (end_cursor), pas des offsets. Ne pas construire le curseur manuellement — utiliser uniquement la valeur retournée par l'API.",
+    "Pour récupérer toutes les transactions d'un jour, boucler tant que page_info.has_next_page === true en passant end_cursor comme paramètre after."
+  ]
+}

--- a/specs/payment/wave/refund_checkout/canonical_example.ts
+++ b/specs/payment/wave/refund_checkout/canonical_example.ts
@@ -1,0 +1,46 @@
+/**
+ * @provider Wave
+ * @capability refund_checkout
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function refundCheckout(sessionId: string): Promise<void> {
+  const response = await fetch(
+    `https://api.wave.com/v1/checkout/sessions/${sessionId}/refund`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${WAVE_API_KEY}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  // HTTP 200 avec corps vide — pas de valeur de retour
+}
+
+/*
+Usage example :
+
+await refundCheckout("cos-abc123");
+// Le montant est recrédité sur le compte Wave du payeur.
+
+// Cet endpoint est idempotent — appeler deux fois ne crée pas un double remboursement.
+// Utile pour les retry en cas de timeout réseau.
+
+// Seules les sessions avec payment_status === 'succeeded' peuvent être remboursées.
+// Vérifier le statut via verify_payment avant d'appeler refundCheckout si nécessaire.
+*/

--- a/specs/payment/wave/refund_checkout/schema.json
+++ b/specs/payment/wave/refund_checkout/schema.json
@@ -7,8 +7,18 @@
   "capability": "refund_checkout",
   "capability_type": "synchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/checkout",
   "docs_public": true,
@@ -25,7 +35,9 @@
   },
   "input_schema": {
     "type": "object",
-    "required": ["id"],
+    "required": [
+      "id"
+    ],
     "properties": {
       "id": {
         "type": "string",
@@ -47,12 +59,31 @@
       "message": {
         "type": "string",
         "description": "Description lisible de l'erreur."
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
       }
     }
   },
   "gotchas": [
     "Cet endpoint est idempotent — appeler refund deux fois sur la même session retourne HTTP 200 sans créer de remboursement en double.",
     "Seule une session avec payment_status 'succeeded' peut être remboursée. Appeler refund sur une session non complétée retourne une erreur.",
-    "Le remboursement est total — Wave ne supporte pas les remboursements partiels via cet endpoint."
+    "Le remboursement est total — Wave ne supporte pas les remboursements partiels via cet endpoint.",
+    "Alternative par transaction ID : si l'ID de session est perdu mais que le transaction_id Wave est connu, utiliser POST /v1/transactions/{transaction_id}/refund (Balance API) pour rembourser par transaction."
   ]
 }

--- a/specs/payment/wave/refund_checkout/schema.json
+++ b/specs/payment/wave/refund_checkout/schema.json
@@ -1,0 +1,58 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "refund_checkout",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/checkout",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.wave.com/v1/checkout/sessions/{id}/refund"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifiant de la session checkout à rembourser (préfixe \"cos-\")."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "description": "HTTP 200 avec corps vide en cas de succès."
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "string",
+        "description": "Code d'erreur. Ex: checkout-session-not-found (404), checkout-refund-failed (500)."
+      },
+      "message": {
+        "type": "string",
+        "description": "Description lisible de l'erreur."
+      }
+    }
+  },
+  "gotchas": [
+    "Cet endpoint est idempotent — appeler refund deux fois sur la même session retourne HTTP 200 sans créer de remboursement en double.",
+    "Seule une session avec payment_status 'succeeded' peut être remboursée. Appeler refund sur une session non complétée retourne une erreur.",
+    "Le remboursement est total — Wave ne supporte pas les remboursements partiels via cet endpoint."
+  ]
+}

--- a/specs/payment/wave/search_checkouts/canonical_example.ts
+++ b/specs/payment/wave/search_checkouts/canonical_example.ts
@@ -1,0 +1,74 @@
+/**
+ * @provider Wave
+ * @capability search_checkouts
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface CheckoutSession {
+  id: string;
+  checkout_status: "open" | "complete" | "expired";
+  payment_status: "processing" | "cancelled" | "succeeded";
+  amount: string;
+  currency: string;
+  client_reference?: string;
+  transaction_id?: string;
+  when_created: string;
+  when_expires: string;
+  when_completed?: string;
+}
+
+interface SearchCheckoutsResponse {
+  result: CheckoutSession[];
+}
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function searchCheckouts(
+  clientReference: string
+): Promise<CheckoutSession[]> {
+  const url = new URL("https://api.wave.com/v1/checkout/sessions/search");
+  url.searchParams.set("client_reference", clientReference);
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${WAVE_API_KEY}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  const data = (await response.json()) as SearchCheckoutsResponse;
+  return data.result;
+}
+
+/*
+Usage example — récupérer une session perdue (session.id non stocké) :
+
+const sessions = await searchCheckouts("order_123");
+
+// Trouver la session payée parmi les résultats
+const paid = sessions.find(
+  (s) => s.checkout_status === "complete" && s.payment_status === "succeeded"
+);
+
+if (paid) {
+  console.log("Session payée retrouvée :", paid.id, paid.transaction_id);
+  await db.orders.update({ client_reference: "order_123" }, { status: "paid", wave_session_id: paid.id });
+} else {
+  console.log("Aucun paiement réussi pour order_123");
+}
+
+// Conseil : toujours utiliser un client_reference unique par commande
+// pour que cette recherche retourne exactement un résultat.
+*/

--- a/specs/payment/wave/search_checkouts/schema.json
+++ b/specs/payment/wave/search_checkouts/schema.json
@@ -1,0 +1,77 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "search_checkouts",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/checkout",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.wave.com/v1/checkout/sessions/search"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["client_reference"],
+    "properties": {
+      "client_reference": {
+        "type": "string",
+        "description": "Référence interne fournie à la création de la session (max 255 chars). Retourne toutes les sessions correspondantes."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "result": {
+        "type": "array",
+        "description": "Liste des sessions checkout correspondant au client_reference.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "checkout_status": {
+              "type": "string",
+              "enum": ["open", "complete", "expired"]
+            },
+            "payment_status": {
+              "type": "string",
+              "enum": ["processing", "cancelled", "succeeded"]
+            },
+            "amount": { "type": "string" },
+            "currency": { "type": "string" },
+            "client_reference": { "type": "string" },
+            "transaction_id": { "type": "string" },
+            "when_created": { "type": "string", "format": "date-time" },
+            "when_expires": { "type": "string", "format": "date-time" },
+            "when_completed": { "type": "string", "format": "date-time" }
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": { "type": "string" },
+      "message": { "type": "string" }
+    }
+  },
+  "gotchas": [
+    "Si client_reference n'est pas unique par commande dans votre système, la recherche peut retourner plusieurs sessions — filtrer sur checkout_status === 'complete' && payment_status === 'succeeded' pour identifier la session payée.",
+    "Cet endpoint est le mécanisme de récupération principal quand session.id n'a pas été stocké (crash serveur entre create et redirect). Toujours passer un client_reference à la création pour pouvoir retrouver la session."
+  ]
+}

--- a/specs/payment/wave/search_checkouts/schema.json
+++ b/specs/payment/wave/search_checkouts/schema.json
@@ -7,8 +7,18 @@
   "capability": "search_checkouts",
   "capability_type": "synchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/checkout",
   "docs_public": true,
@@ -25,7 +35,9 @@
   },
   "input_schema": {
     "type": "object",
-    "required": ["client_reference"],
+    "required": [
+      "client_reference"
+    ],
     "properties": {
       "client_reference": {
         "type": "string",
@@ -42,22 +54,49 @@
         "items": {
           "type": "object",
           "properties": {
-            "id": { "type": "string" },
+            "id": {
+              "type": "string"
+            },
             "checkout_status": {
               "type": "string",
-              "enum": ["open", "complete", "expired"]
+              "enum": [
+                "open",
+                "complete",
+                "expired"
+              ]
             },
             "payment_status": {
               "type": "string",
-              "enum": ["processing", "cancelled", "succeeded"]
+              "enum": [
+                "processing",
+                "cancelled",
+                "succeeded"
+              ]
             },
-            "amount": { "type": "string" },
-            "currency": { "type": "string" },
-            "client_reference": { "type": "string" },
-            "transaction_id": { "type": "string" },
-            "when_created": { "type": "string", "format": "date-time" },
-            "when_expires": { "type": "string", "format": "date-time" },
-            "when_completed": { "type": "string", "format": "date-time" }
+            "amount": {
+              "type": "string"
+            },
+            "currency": {
+              "type": "string"
+            },
+            "client_reference": {
+              "type": "string"
+            },
+            "transaction_id": {
+              "type": "string"
+            },
+            "when_created": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "when_expires": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "when_completed": {
+              "type": "string",
+              "format": "date-time"
+            }
           }
         }
       }
@@ -66,8 +105,30 @@
   "error_schema": {
     "type": "object",
     "properties": {
-      "code": { "type": "string" },
-      "message": { "type": "string" }
+      "code": {
+        "type": "string"
+      },
+      "message": {
+        "type": "string"
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   },
   "gotchas": [

--- a/specs/payment/wave/send_payout/canonical_example.ts
+++ b/specs/payment/wave/send_payout/canonical_example.ts
@@ -28,7 +28,10 @@ interface PayoutResponse {
   fee: string;
   mobile: string;
   name?: string;
+  national_id?: string;
   client_reference?: string;
+  payment_reason?: string;
+  aggregated_merchant_id?: string;
   timestamp: string;
   payout_error?: { error_code: string; error_message?: string };
 }

--- a/specs/payment/wave/send_payout/canonical_example.ts
+++ b/specs/payment/wave/send_payout/canonical_example.ts
@@ -1,0 +1,100 @@
+/**
+ * @provider Wave
+ * @capability send_payout
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+import { randomUUID } from "crypto";
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface SendPayoutInput {
+  currency: string;
+  receive_amount: string;
+  mobile: string;
+  name?: string;
+  national_id?: string;
+  client_reference?: string;
+  payment_reason?: string;
+}
+
+interface PayoutResponse {
+  id: string;
+  status: "processing" | "succeeded" | "failed";
+  currency: string;
+  receive_amount: string;
+  fee: string;
+  mobile: string;
+  name?: string;
+  client_reference?: string;
+  timestamp: string;
+  payout_error?: { error_code: string; error_message?: string };
+}
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function sendPayout(
+  input: SendPayoutInput,
+  idempotencyKey: string = randomUUID()
+): Promise<PayoutResponse> {
+  const response = await fetch("https://api.wave.com/v1/payout", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${WAVE_API_KEY}`,
+      "Content-Type": "application/json",
+      "Idempotency-Key": idempotencyKey,
+    },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  return response.json() as Promise<PayoutResponse>;
+}
+
+/*
+Usage example :
+
+// Générer et stocker l'idempotency key AVANT l'appel — en cas de retry, réutiliser la même key.
+const idempotencyKey = randomUUID();
+await db.payouts.create({ idempotency_key: idempotencyKey, status: "pending", mobile: "+221700000000" });
+
+let payout: PayoutResponse;
+try {
+  payout = await sendPayout(
+    {
+      currency: "XOF",
+      receive_amount: "5000",   // string, sans décimales
+      mobile: "+221700000000",  // format E.164
+      client_reference: "withdrawal_456",
+      payment_reason: "Remboursement commande",
+    },
+    idempotencyKey
+  );
+} catch (err) {
+  // Erreur réseau ou 5xx : retenter avec le MÊME idempotencyKey + backoff exponentiel
+  // Erreur 4xx (insufficient-funds, etc.) : marquer comme failed définitivement
+  throw err;
+}
+
+if (payout.status === "succeeded") {
+  await db.payouts.update({ idempotency_key: idempotencyKey }, { status: "succeeded", payout_id: payout.id });
+} else if (payout.status === "processing") {
+  // Pas encore définitif — surveiller via GET /v1/payout/{id}
+  await db.payouts.update({ idempotency_key: idempotencyKey }, { status: "processing", payout_id: payout.id });
+} else {
+  // failed
+  await db.payouts.update({ idempotency_key: idempotencyKey }, { status: "failed", error: payout.payout_error?.error_code });
+}
+
+// IMPORTANT : ne jamais marquer "failed" un payout en status "processing".
+// L'utilisateur pourrait retenter, causant un doublon si le payout finit par réussir.
+*/

--- a/specs/payment/wave/send_payout/canonical_example.ts
+++ b/specs/payment/wave/send_payout/canonical_example.ts
@@ -22,7 +22,7 @@ interface SendPayoutInput {
 
 interface PayoutResponse {
   id: string;
-  status: "processing" | "succeeded" | "failed";
+  status: "processing" | "succeeded" | "failed" | "reversed";
   currency: string;
   receive_amount: string;
   fee: string;

--- a/specs/payment/wave/send_payout/schema.json
+++ b/specs/payment/wave/send_payout/schema.json
@@ -7,8 +7,18 @@
   "capability": "send_payout",
   "capability_type": "synchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/payout",
   "docs_public": true,
@@ -25,7 +35,11 @@
   },
   "input_schema": {
     "type": "object",
-    "required": ["currency", "receive_amount", "mobile"],
+    "required": [
+      "currency",
+      "receive_amount",
+      "mobile"
+    ],
     "properties": {
       "currency": {
         "type": "string",
@@ -66,11 +80,16 @@
     "properties": {
       "id": {
         "type": "string",
-        "description": "Identifiant unique du payout (max 20 chars). Stocker pour pouvoir faire un reversal ou suivre le statut."
+        "description": "Identifiant unique du payout (préfixe \"pt-\", max 20 chars). Stocker pour pouvoir faire un reversal ou suivre le statut via get_payout."
       },
       "status": {
         "type": "string",
-        "enum": ["processing", "succeeded", "failed", "reversed"],
+        "enum": [
+          "processing",
+          "succeeded",
+          "failed",
+          "reversed"
+        ],
         "description": "État du payout. 'processing' signifie que le résultat n'est pas encore définitif. 'reversed' indique que le payout a été annulé via POST /v1/payout/{id}/reverse."
       },
       "currency": {
@@ -106,8 +125,12 @@
         "type": "object",
         "description": "Présent uniquement si status est 'failed'.",
         "properties": {
-          "error_code": { "type": "string" },
-          "error_message": { "type": "string" }
+          "error_code": {
+            "type": "string"
+          },
+          "error_message": {
+            "type": "string"
+          }
         }
       }
     }
@@ -122,6 +145,24 @@
       "message": {
         "type": "string",
         "description": "Description lisible de l'erreur."
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
       }
     }
   },

--- a/specs/payment/wave/send_payout/schema.json
+++ b/specs/payment/wave/send_payout/schema.json
@@ -1,0 +1,132 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "send_payout",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/payout",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.wave.com/v1/payout"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["currency", "receive_amount", "mobile"],
+    "properties": {
+      "currency": {
+        "type": "string",
+        "description": "Code ISO 4217 en majuscules. Ex: \"XOF\", \"GNF\", \"UGX\"."
+      },
+      "receive_amount": {
+        "type": "string",
+        "description": "Montant que le destinataire reçoit, en string, sans décimales. Ex: \"5000\"."
+      },
+      "mobile": {
+        "type": "string",
+        "description": "Numéro de téléphone du destinataire au format E.164. Ex: \"+221700000000\"."
+      },
+      "name": {
+        "type": "string",
+        "description": "Nom du destinataire (max 255 chars). Utilisé pour la vérification si national_id est aussi fourni."
+      },
+      "national_id": {
+        "type": "string",
+        "description": "Numéro de pièce d'identité nationale du destinataire (max 255 chars). Optionnel."
+      },
+      "client_reference": {
+        "type": "string",
+        "description": "Référence interne (max 255 chars) pour corréler le payout avec votre système."
+      },
+      "payment_reason": {
+        "type": "string",
+        "description": "Motif du paiement visible par le destinataire (max 40 chars)."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifiant unique du payout (max 20 chars). Stocker pour pouvoir faire un reversal ou suivre le statut."
+      },
+      "status": {
+        "type": "string",
+        "enum": ["processing", "succeeded", "failed"],
+        "description": "État du payout. 'processing' signifie que le résultat n'est pas encore définitif."
+      },
+      "currency": {
+        "type": "string",
+        "description": "Code ISO 4217."
+      },
+      "receive_amount": {
+        "type": "string",
+        "description": "Montant reçu par le destinataire."
+      },
+      "fee": {
+        "type": "string",
+        "description": "Frais prélevés sur votre wallet."
+      },
+      "mobile": {
+        "type": "string",
+        "description": "Numéro E.164 du destinataire."
+      },
+      "name": {
+        "type": "string",
+        "description": "Nom du destinataire si fourni."
+      },
+      "client_reference": {
+        "type": "string",
+        "description": "Référence interne si fournie."
+      },
+      "timestamp": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Horodatage ISO 8601 UTC du payout."
+      },
+      "payout_error": {
+        "type": "object",
+        "description": "Présent uniquement si status est 'failed'.",
+        "properties": {
+          "error_code": { "type": "string" },
+          "error_message": { "type": "string" }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "string",
+        "description": "Code d'erreur. Ex: insufficient-funds, recipient-account-blocked, idempotency-mismatch."
+      },
+      "message": {
+        "type": "string",
+        "description": "Description lisible de l'erreur."
+      }
+    }
+  },
+  "gotchas": [
+    "Chaque requête POST /v1/payout doit inclure un header Idempotency-Key unique (UUID v4 recommandé, max 255 chars). Sans cette clé, un retry en cas d'erreur réseau peut créer un payout en double.",
+    "Si le payout retourne status 'processing', ne pas le marquer comme échoué — le considérer comme pending et surveiller via GET /v1/payout/{id}. Marquer comme échoué trop tôt peut pousser l'utilisateur à retenter, causant un doublon.",
+    "En cas d'erreur 5xx, timeout ou connexion interrompue : retenter avec le MÊME Idempotency-Key et un backoff exponentiel. Wave garantit l'idempotence.",
+    "En cas d'erreur 'idempotency-mismatch' (409) : le même Idempotency-Key a été utilisé avec un body différent. Générer un nouveau key et retenter.",
+    "Le reversal d'un payout est limité à 3 jours après création. Après ce délai, POST /v1/payout/{id}/reverse retourne une erreur.",
+    "receive_amount est une string sans décimales pour XOF — envoyer \"5000\" et non 5000 ou \"5000.00\"."
+  ]
+}

--- a/specs/payment/wave/send_payout/schema.json
+++ b/specs/payment/wave/send_payout/schema.json
@@ -54,6 +54,10 @@
       "payment_reason": {
         "type": "string",
         "description": "Motif du paiement visible par le destinataire (max 40 chars)."
+      },
+      "aggregated_merchant_id": {
+        "type": "string",
+        "description": "ID de marchand agrégé. Requis pour les agrégateurs ayant activé l'API Aggregated Merchants."
       }
     }
   },
@@ -66,8 +70,8 @@
       },
       "status": {
         "type": "string",
-        "enum": ["processing", "succeeded", "failed"],
-        "description": "État du payout. 'processing' signifie que le résultat n'est pas encore définitif."
+        "enum": ["processing", "succeeded", "failed", "reversed"],
+        "description": "État du payout. 'processing' signifie que le résultat n'est pas encore définitif. 'reversed' indique que le payout a été annulé via POST /v1/payout/{id}/reverse."
       },
       "currency": {
         "type": "string",

--- a/specs/payment/wave/verify_payment/canonical_example.ts
+++ b/specs/payment/wave/verify_payment/canonical_example.ts
@@ -1,0 +1,76 @@
+/**
+ * @provider Wave
+ * @capability verify_payment
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface CheckoutSession {
+  id: string;
+  checkout_status: "open" | "complete" | "expired";
+  payment_status: "processing" | "cancelled" | "succeeded";
+  amount: string;
+  currency: string;
+  transaction_id?: string;
+  client_reference?: string;
+  business_name: string;
+  when_created: string;
+  when_expires: string;
+  when_completed?: string;
+  last_payment_error?: { code: string; message: string };
+}
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function verifyPayment(sessionId: string): Promise<CheckoutSession> {
+  const response = await fetch(
+    `https://api.wave.com/v1/checkout/sessions/${sessionId}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${WAVE_API_KEY}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  return response.json() as Promise<CheckoutSession>;
+}
+
+export function isPaymentSucceeded(session: CheckoutSession): boolean {
+  return (
+    session.checkout_status === "complete" &&
+    session.payment_status === "succeeded"
+  );
+}
+
+/*
+Usage example (handler success_url ou fallback webhook) :
+
+const session = await verifyPayment("cos-abc123");
+
+if (isPaymentSucceeded(session)) {
+  // Valider la commande
+  await db.orders.update(
+    { wave_session_id: session.id },
+    { status: "paid", transaction_id: session.transaction_id }
+  );
+} else {
+  // checkout_status peut être 'open' (pas encore payé) ou 'expired'
+  // payment_status peut être 'processing' (en cours) ou 'cancelled'
+  console.log("Paiement non complété :", session.checkout_status, session.payment_status);
+}
+
+// Toujours vérifier les DEUX champs :
+// checkout_status === 'complete' ET payment_status === 'succeeded'
+*/

--- a/specs/payment/wave/verify_payment/schema.json
+++ b/specs/payment/wave/verify_payment/schema.json
@@ -7,8 +7,18 @@
   "capability": "verify_payment",
   "capability_type": "synchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/checkout",
   "docs_public": true,
@@ -25,7 +35,9 @@
   },
   "input_schema": {
     "type": "object",
-    "required": ["id"],
+    "required": [
+      "id"
+    ],
     "properties": {
       "id": {
         "type": "string",
@@ -42,12 +54,21 @@
       },
       "checkout_status": {
         "type": "string",
-        "enum": ["open", "complete", "expired"],
-        "description": "État de la session. Vérifier que checkout_status est 'complete' ET payment_status est 'succeeded' avant de valider une commande."
+        "enum": [
+          "open",
+          "complete",
+          "expired",
+          "failed"
+        ],
+        "description": "État de la session. Vérifier que checkout_status est 'complete' ET payment_status est 'succeeded' avant de valider une commande. 'failed' peut apparaître dans le contexte du webhook checkout.session.payment_failed."
       },
       "payment_status": {
         "type": "string",
-        "enum": ["processing", "cancelled", "succeeded"],
+        "enum": [
+          "processing",
+          "cancelled",
+          "succeeded"
+        ],
         "description": "État du paiement."
       },
       "amount": {
@@ -89,8 +110,12 @@
         "type": "object",
         "description": "Dernière erreur de paiement. Présent si payment_status est processing ou cancelled.",
         "properties": {
-          "code": { "type": "string" },
-          "message": { "type": "string" }
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     }
@@ -105,6 +130,24 @@
       "message": {
         "type": "string",
         "description": "Description lisible de l'erreur."
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
       }
     }
   },

--- a/specs/payment/wave/verify_payment/schema.json
+++ b/specs/payment/wave/verify_payment/schema.json
@@ -1,0 +1,116 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "verify_payment",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/checkout",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.wave.com/v1/checkout/sessions/{id}"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifiant de la session de checkout (préfixe \"cos-\"). Récupéré depuis la réponse de create_checkout_session."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifiant unique de la session."
+      },
+      "checkout_status": {
+        "type": "string",
+        "enum": ["open", "complete", "expired"],
+        "description": "État de la session. Vérifier que checkout_status est 'complete' ET payment_status est 'succeeded' avant de valider une commande."
+      },
+      "payment_status": {
+        "type": "string",
+        "enum": ["processing", "cancelled", "succeeded"],
+        "description": "État du paiement."
+      },
+      "amount": {
+        "type": "string",
+        "description": "Montant demandé."
+      },
+      "currency": {
+        "type": "string",
+        "description": "Code ISO 4217."
+      },
+      "transaction_id": {
+        "type": "string",
+        "description": "Identifiant de transaction Wave. Présent uniquement si le paiement a été initié."
+      },
+      "client_reference": {
+        "type": "string",
+        "description": "Référence interne fournie à la création."
+      },
+      "business_name": {
+        "type": "string",
+        "description": "Nom du business affiché au payeur."
+      },
+      "when_created": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Horodatage ISO 8601 UTC de création."
+      },
+      "when_expires": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Horodatage ISO 8601 UTC d'expiration."
+      },
+      "when_completed": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Horodatage ISO 8601 UTC de complétion. Absent si la session est encore ouverte."
+      },
+      "last_payment_error": {
+        "type": "object",
+        "description": "Dernière erreur de paiement. Présent si payment_status est processing ou cancelled.",
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "string",
+        "description": "Code d'erreur. Ex: checkout-session-not-found, unauthorized-wallet."
+      },
+      "message": {
+        "type": "string",
+        "description": "Description lisible de l'erreur."
+      }
+    }
+  },
+  "gotchas": [
+    "Toujours vérifier côté serveur avant de valider une commande — ne jamais se fier uniquement au success_url ou au webhook. Un utilisateur peut manipuler la redirection.",
+    "Vérifier les DEUX champs : checkout_status === 'complete' ET payment_status === 'succeeded'. Un checkout_status 'complete' avec payment_status 'cancelled' signifie que le paiement a échoué.",
+    "verify_payment est aussi le mécanisme de récupération si le webhook n'a pas été reçu (timeout, serveur indisponible, redémarrage)."
+  ]
+}

--- a/specs/payment/wave/verify_recipient/canonical_example.ts
+++ b/specs/payment/wave/verify_recipient/canonical_example.ts
@@ -1,0 +1,79 @@
+/**
+ * @provider Wave
+ * @capability verify_recipient
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+interface VerifyRecipientInput {
+  mobile: string;
+  name?: string;
+  national_id?: string;
+  amount?: string;
+  currency?: string;
+}
+
+interface VerifyRecipientResponse {
+  within_limits: boolean | null;
+  name_match: "MATCH" | "NO_MATCH" | "NAME_NOT_KNOWN" | null;
+  national_id_match: "MATCH" | "NO_MATCH" | "ID_NOT_KNOWN" | null;
+}
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+export async function verifyRecipient(
+  input: VerifyRecipientInput
+): Promise<VerifyRecipientResponse> {
+  const response = await fetch("https://api.wave.com/v1/verify_recipient", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${WAVE_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  return response.json() as Promise<VerifyRecipientResponse>;
+}
+
+/*
+Usage example :
+
+const result = await verifyRecipient({
+  mobile: "+221700000000",
+  name: "Mamadou Diallo",
+  amount: "50000",
+  currency: "XOF",
+});
+
+// Vérifier la capacité à recevoir le montant
+if (result.within_limits === false) {
+  throw new Error("Le destinataire ne peut pas recevoir ce montant (limite dépassée)");
+}
+
+// Vérifier le nom
+if (result.name_match === "NO_MATCH") {
+  // Avertir l'utilisateur — ne pas bloquer automatiquement
+  console.warn("Le nom fourni ne correspond pas au compte Wave");
+}
+
+// NAME_NOT_KNOWN = le destinataire n'est pas KYC-2 chez Wave
+// Ce n'est pas une erreur — ne pas bloquer le payout sur cette base
+if (result.name_match === "NAME_NOT_KNOWN") {
+  console.log("Vérification du nom impossible : données KYC insuffisantes");
+}
+
+// ATTENTION : max 30 vérifications du même numéro par 5 minutes
+// Au-delà, ce numéro est bloqué 60 minutes
+*/

--- a/specs/payment/wave/verify_recipient/schema.json
+++ b/specs/payment/wave/verify_recipient/schema.json
@@ -1,0 +1,90 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "verify_recipient",
+  "capability_type": "synchronous",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/payout",
+  "docs_public": true,
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "WAVE_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.wave.com/v1/verify_recipient"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["mobile"],
+    "properties": {
+      "mobile": {
+        "type": "string",
+        "description": "Numéro de téléphone du destinataire au format E.164. Ex: \"+221700000000\"."
+      },
+      "name": {
+        "type": "string",
+        "description": "Nom attendu du destinataire. Si fourni, Wave retourne name_match indiquant si le nom correspond."
+      },
+      "national_id": {
+        "type": "string",
+        "description": "Numéro de pièce d'identité nationale attendu. Retourne national_id_match si fourni."
+      },
+      "amount": {
+        "type": "string",
+        "description": "Montant prévu du payout. Si fourni, Wave retourne within_limits indiquant si le destinataire peut recevoir ce montant."
+      },
+      "currency": {
+        "type": "string",
+        "description": "Code ISO 4217. Requis si amount est fourni."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "within_limits": {
+        "type": ["boolean", "null"],
+        "description": "true si le destinataire peut recevoir le montant demandé. null si amount n'a pas été fourni."
+      },
+      "name_match": {
+        "type": ["string", "null"],
+        "enum": ["MATCH", "NO_MATCH", "NAME_NOT_KNOWN", null],
+        "description": "Résultat de la comparaison du nom (algorithme Jaro-Winkler, seuil 0.65). NAME_NOT_KNOWN si le destinataire n'est pas KYC-2. null si name n'a pas été fourni."
+      },
+      "national_id_match": {
+        "type": ["string", "null"],
+        "enum": ["MATCH", "NO_MATCH", "ID_NOT_KNOWN", null],
+        "description": "Résultat de la vérification de la pièce d'identité. null si national_id n'a pas été fourni."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "code": {
+        "type": "string",
+        "description": "Code d'erreur. Ex: too-many-requests si la limite de 30 vérifications par 5 min est dépassée."
+      },
+      "message": {
+        "type": "string",
+        "description": "Description lisible de l'erreur."
+      }
+    }
+  },
+  "gotchas": [
+    "Limite de rate : 30 vérifications pour le même numéro dans une fenêtre de 5 minutes. Au-delà, ce numéro est bloqué pendant 60 minutes.",
+    "NAME_NOT_KNOWN ne signifie pas que le nom est incorrect — cela signifie que Wave n'a pas d'information légale sur ce destinataire (non KYC-2). Ne pas bloquer un payout sur cette base seule.",
+    "La comparaison de nom utilise Jaro-Winkler avec un seuil de 0.65 — les variations orthographiques mineures (accents, abréviations) peuvent retourner MATCH.",
+    "national_id_match nécessite une activation spécifique par Wave. Sans cette activation, le champ retourne toujours null même si national_id est fourni."
+  ]
+}

--- a/specs/payment/wave/verify_recipient/schema.json
+++ b/specs/payment/wave/verify_recipient/schema.json
@@ -7,8 +7,18 @@
   "capability": "verify_recipient",
   "capability_type": "synchronous",
   "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG"],
-  "currency": ["XOF", "GNF", "UGX"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG"
+  ],
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/payout",
   "docs_public": true,
@@ -25,7 +35,9 @@
   },
   "input_schema": {
     "type": "object",
-    "required": ["mobile"],
+    "required": [
+      "mobile"
+    ],
     "properties": {
       "mobile": {
         "type": "string",
@@ -53,17 +65,36 @@
     "type": "object",
     "properties": {
       "within_limits": {
-        "type": ["boolean", "null"],
+        "type": [
+          "boolean",
+          "null"
+        ],
         "description": "true si le destinataire peut recevoir le montant demandé. null si amount n'a pas été fourni."
       },
       "name_match": {
-        "type": ["string", "null"],
-        "enum": ["MATCH", "NO_MATCH", "NAME_NOT_KNOWN", null],
+        "type": [
+          "string",
+          "null"
+        ],
+        "enum": [
+          "MATCH",
+          "NO_MATCH",
+          "NAME_NOT_KNOWN",
+          null
+        ],
         "description": "Résultat de la comparaison du nom (algorithme Jaro-Winkler, seuil 0.65). NAME_NOT_KNOWN si le destinataire n'est pas KYC-2. null si name n'a pas été fourni."
       },
       "national_id_match": {
-        "type": ["string", "null"],
-        "enum": ["MATCH", "NO_MATCH", "ID_NOT_KNOWN", null],
+        "type": [
+          "string",
+          "null"
+        ],
+        "enum": [
+          "MATCH",
+          "NO_MATCH",
+          "ID_NOT_KNOWN",
+          null
+        ],
         "description": "Résultat de la vérification de la pièce d'identité. null si national_id n'a pas été fourni."
       }
     }
@@ -78,11 +109,29 @@
       "message": {
         "type": "string",
         "description": "Description lisible de l'erreur."
+      },
+      "details": {
+        "type": "array",
+        "description": "Détails de validation retournés sur request-validation-error. Chaque entrée contient loc (localisation du champ), msg (message), type (type d erreur).",
+        "items": {
+          "type": "object",
+          "properties": {
+            "loc": {
+              "type": "string"
+            },
+            "msg": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
       }
     }
   },
   "gotchas": [
-    "Limite de rate : 30 vérifications pour le même numéro dans une fenêtre de 5 minutes. Au-delà, ce numéro est bloqué pendant 60 minutes.",
+    "Limite de rate : 30 vérifications incluant une comparaison de nom (champ name fourni) pour le même numéro dans une fenêtre de 5 minutes. Au-delà, ce numéro est bloqué pendant 60 minutes. Les appels sans name ne sont pas soumis à cette limite.",
     "NAME_NOT_KNOWN ne signifie pas que le nom est incorrect — cela signifie que Wave n'a pas d'information légale sur ce destinataire (non KYC-2). Ne pas bloquer un payout sur cette base seule.",
     "La comparaison de nom utilise Jaro-Winkler avec un seuil de 0.65 — les variations orthographiques mineures (accents, abréviations) peuvent retourner MATCH.",
     "national_id_match nécessite une activation spécifique par Wave. Sans cette activation, le champ retourne toujours null même si national_id est fourni."

--- a/specs/payment/wave/webhook_payment_completed/canonical_example.ts
+++ b/specs/payment/wave/webhook_payment_completed/canonical_example.ts
@@ -68,7 +68,13 @@ function verifyWaveSignature(
   const payload = timestamp + rawBody;
   const expected = createHmac("sha256", secret).update(payload).digest("hex");
 
-  return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+  // timingSafeEqual throws si les buffers n'ont pas la même longueur.
+  // Vérifier d'abord la longueur pour éviter une exception sur signature malformée.
+  const sigBuf = Buffer.from(signature);
+  const expBuf = Buffer.from(expected);
+  if (sigBuf.length !== expBuf.length) return false;
+
+  return timingSafeEqual(sigBuf, expBuf);
 }
 
 async function verifyPaymentServerSide(sessionId: string): Promise<CheckoutSession> {

--- a/specs/payment/wave/webhook_payment_completed/canonical_example.ts
+++ b/specs/payment/wave/webhook_payment_completed/canonical_example.ts
@@ -51,15 +51,21 @@ function verifyWaveSignature(
   secret: string
 ): boolean {
   // Format: "t=1234567890,v1=abc123..."
-  const parts: Record<string, string> = {};
+  // Pendant une rotation de secret, Wave envoie plusieurs valeurs v1= dans le même header.
+  // Utiliser un tableau pour toutes les capturer — ne pas écraser avec un simple map.
+  let timestamp: string | undefined;
+  const signatures: string[] = [];
+
   for (const part of signatureHeader.split(",")) {
-    const [key, value] = part.split("=");
-    if (key && value) parts[key] = value;
+    const eqIdx = part.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = part.slice(0, eqIdx);
+    const value = part.slice(eqIdx + 1);
+    if (key === "t") timestamp = value;
+    else if (key === "v1") signatures.push(value);
   }
 
-  const timestamp = parts["t"];
-  const signature = parts["v1"];
-  if (!timestamp || !signature) return false;
+  if (!timestamp || signatures.length === 0) return false;
 
   // Rejeter les requêtes de plus de 5 minutes
   const now = Math.floor(Date.now() / 1000);
@@ -67,14 +73,15 @@ function verifyWaveSignature(
 
   const payload = timestamp + rawBody;
   const expected = createHmac("sha256", secret).update(payload).digest("hex");
-
-  // timingSafeEqual throws si les buffers n'ont pas la même longueur.
-  // Vérifier d'abord la longueur pour éviter une exception sur signature malformée.
-  const sigBuf = Buffer.from(signature);
   const expBuf = Buffer.from(expected);
-  if (sigBuf.length !== expBuf.length) return false;
 
-  return timingSafeEqual(sigBuf, expBuf);
+  // Vérifier si l'une des signatures correspond (cas multi-signatures lors d'une rotation)
+  return signatures.some((sig) => {
+    const sigBuf = Buffer.from(sig);
+    // timingSafeEqual throws si longueurs différentes — vérifier d'abord
+    if (sigBuf.length !== expBuf.length) return false;
+    return timingSafeEqual(sigBuf, expBuf);
+  });
 }
 
 async function verifyPaymentServerSide(sessionId: string): Promise<CheckoutSession> {

--- a/specs/payment/wave/webhook_payment_completed/canonical_example.ts
+++ b/specs/payment/wave/webhook_payment_completed/canonical_example.ts
@@ -1,0 +1,165 @@
+/**
+ * @provider Wave
+ * @capability webhook_payment_completed
+ * @atss 1.0
+ * @capability_type webhook
+ */
+
+import { createHmac, timingSafeEqual } from "crypto";
+
+const WAVE_API_KEY = process.env.WAVE_API_KEY;
+if (!WAVE_API_KEY) throw new Error("Missing env: WAVE_API_KEY");
+
+const WAVE_WEBHOOK_SECRET = process.env.WAVE_WEBHOOK_SECRET;
+if (!WAVE_WEBHOOK_SECRET) throw new Error("Missing env: WAVE_WEBHOOK_SECRET");
+
+interface WaveCheckoutSessionData {
+  id: string;
+  checkout_status: "complete";
+  payment_status: "succeeded";
+  amount: string;
+  currency: string;
+  transaction_id: string;
+  client_reference?: string;
+  when_completed: string;
+}
+
+interface WaveWebhookPayload {
+  id: string;
+  type: "checkout.session.completed";
+  data: WaveCheckoutSessionData;
+}
+
+interface CheckoutSession {
+  id: string;
+  checkout_status: "open" | "complete" | "expired";
+  payment_status: "processing" | "cancelled" | "succeeded";
+  amount: string;
+  currency: string;
+  transaction_id?: string;
+  client_reference?: string;
+}
+
+interface WaveError {
+  code: string;
+  message: string;
+}
+
+function verifyWaveSignature(
+  rawBody: string,
+  signatureHeader: string,
+  secret: string
+): boolean {
+  // Format: "t=1234567890,v1=abc123..."
+  const parts: Record<string, string> = {};
+  for (const part of signatureHeader.split(",")) {
+    const [key, value] = part.split("=");
+    if (key && value) parts[key] = value;
+  }
+
+  const timestamp = parts["t"];
+  const signature = parts["v1"];
+  if (!timestamp || !signature) return false;
+
+  // Rejeter les requêtes de plus de 5 minutes
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - parseInt(timestamp, 10)) > 300) return false;
+
+  const payload = timestamp + rawBody;
+  const expected = createHmac("sha256", secret).update(payload).digest("hex");
+
+  return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+}
+
+async function verifyPaymentServerSide(sessionId: string): Promise<CheckoutSession> {
+  const response = await fetch(
+    `https://api.wave.com/v1/checkout/sessions/${sessionId}`,
+    {
+      method: "GET",
+      headers: { Authorization: `Bearer ${WAVE_API_KEY}` },
+    }
+  );
+
+  if (!response.ok) {
+    const error: WaveError = await response.json();
+    throw new Error(`Wave verify error ${response.status}: ${error.message ?? error.code}`);
+  }
+
+  return response.json() as Promise<CheckoutSession>;
+}
+
+/**
+ * Express-style webhook handler pour checkout.session.completed.
+ * Monter à l'URL configurée dans le Wave Business Portal.
+ */
+export async function handleWaveWebhook(
+  rawBody: string,
+  signatureHeader: string,
+  fulfillOrder: (sessionId: string, clientReference: string | undefined, currency: string) => Promise<void>,
+  sendResponse: (status: number) => void
+): Promise<void> {
+  // Répondre 200 immédiatement — Wave retry 3 jours si pas de réponse dans 5s
+  sendResponse(200);
+
+  if (!verifyWaveSignature(rawBody, signatureHeader, WAVE_WEBHOOK_SECRET!)) {
+    // Signature invalide — ignorer silencieusement (déjà répondu 200)
+    return;
+  }
+
+  let payload: WaveWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody) as WaveWebhookPayload;
+  } catch {
+    return;
+  }
+
+  if (payload.type !== "checkout.session.completed") return;
+
+  const sessionId = payload.data.id;
+  const eventId = payload.id;
+
+  try {
+    // Vérifier côté serveur — ne jamais se fier au payload seul
+    const session = await verifyPaymentServerSide(sessionId);
+
+    if (
+      session.checkout_status === "complete" &&
+      session.payment_status === "succeeded"
+    ) {
+      // fulfillOrder doit être idempotent via eventId ou sessionId
+      await fulfillOrder(session.id, session.client_reference, session.currency);
+    }
+  } catch {
+    // Logger l'erreur — ne pas rethrow (200 déjà envoyé)
+    // Le webhook sera retenté par Wave
+  }
+}
+
+/*
+Usage example (Express) :
+
+import express from "express";
+const app = express();
+
+// IMPORTANT: utiliser express.raw() — ne pas parser en JSON avant la vérification de signature
+app.post("/api/wave/webhook", express.raw({ type: "application/json" }), async (req, res) => {
+  await handleWaveWebhook(
+    req.body.toString(),
+    req.headers["wave-signature"] as string ?? "",
+    async (sessionId, clientReference, currency) => {
+      // Guard idempotence via l'event id ou le sessionId
+      const already = await db.orders.findOne({ wave_session_id: sessionId, status: "paid" });
+      if (already) return;
+
+      await db.orders.update(
+        { wave_session_id: sessionId },
+        { status: "paid", currency }
+      );
+    },
+    (status) => res.sendStatus(status)
+  );
+});
+
+// Ne pas mettre de middleware d'authentification sur cette route.
+// La vérification se fait via Wave-Signature.
+*/

--- a/specs/payment/wave/webhook_payment_completed/schema.json
+++ b/specs/payment/wave/webhook_payment_completed/schema.json
@@ -1,0 +1,91 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "wave",
+  "provider_name": "Wave",
+  "provider_api_version": "2024-03-29",
+  "category": "payment",
+  "capability": "webhook_payment_completed",
+  "capability_type": "webhook",
+  "status": "compliant",
+  "country_code": ["SN", "CI", "ML", "GN", "UG"],
+  "currency": ["XOF", "GNF", "UGX"],
+  "sandbox": false,
+  "docs_url": "https://docs.wave.com/webhook",
+  "docs_public": true,
+  "auth": {
+    "type": "none"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "{your_webhook_url}"
+  },
+  "input_schema": {
+    "type": "object",
+    "description": "Payload que Wave POSTe à votre endpoint lors d'un événement checkout.session.completed.",
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Identifiant unique de l'événement. Utiliser pour l'idempotence — Wave peut livrer le même événement plusieurs fois."
+      },
+      "type": {
+        "type": "string",
+        "enum": ["checkout.session.completed"],
+        "description": "Type de l'événement."
+      },
+      "data": {
+        "type": "object",
+        "description": "Objet checkout session complet au moment de l'événement.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Identifiant de la session (préfixe \"cos-\")."
+          },
+          "checkout_status": {
+            "type": "string",
+            "enum": ["complete"],
+            "description": "Toujours 'complete' pour cet événement."
+          },
+          "payment_status": {
+            "type": "string",
+            "enum": ["succeeded"],
+            "description": "Toujours 'succeeded' pour cet événement."
+          },
+          "amount": {
+            "type": "string",
+            "description": "Montant du paiement."
+          },
+          "currency": {
+            "type": "string",
+            "description": "Code ISO 4217."
+          },
+          "transaction_id": {
+            "type": "string",
+            "description": "Identifiant de transaction Wave."
+          },
+          "client_reference": {
+            "type": "string",
+            "description": "Référence interne fournie à la création. Utiliser pour retrouver la commande dans votre système."
+          },
+          "when_completed": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Horodatage ISO 8601 UTC de complétion."
+          }
+        }
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "description": "Votre endpoint doit retourner HTTP 2xx dans les 5 secondes. Le corps de la réponse est ignoré par Wave."
+  },
+  "error_schema": {},
+  "gotchas": [
+    "Ne jamais fulfiller une commande sur la base du webhook seul. Appeler verify_payment (GET /v1/checkout/sessions/{id}) pour confirmer côté serveur — le payload webhook peut être forgé.",
+    "Répondre HTTP 200 immédiatement et traiter de façon asynchrone. Wave retry pendant 3 jours si votre endpoint ne répond pas dans les 5 secondes.",
+    "Implémenter l'idempotence via event.id — Wave peut livrer le même événement plusieurs fois. Vérifier que la commande n'est pas déjà fulfillée avant d'agir.",
+    "Vérifier la signature Wave-Signature en production : HMAC-SHA256 du timestamp + raw body. Utiliser le raw body, pas le JSON parsé — certains frameworks modifient le body entre réception et parsing.",
+    "[MUST TELL USER] Wave whitelisté 15 plages d'IPs qui envoient les webhooks. Si votre serveur filtre le trafic entrant, ajouter ces IPs dans votre firewall ou les webhooks échoueront silencieusement. La liste est disponible dans le Business Portal.",
+    "[MUST TELL USER] En développement local, Wave ne peut pas joindre localhost. Utiliser un tunnel HTTPS (ex: `ngrok http 3000`) et configurer l'URL ngrok dans le Business Portal avant de tester."
+  ]
+}

--- a/specs/payment/wave/webhook_payment_completed/schema.json
+++ b/specs/payment/wave/webhook_payment_completed/schema.json
@@ -81,6 +81,7 @@
   },
   "error_schema": {},
   "gotchas": [
+    "Wave envoie aussi l'événement checkout.session.payment_failed lorsqu'un paiement échoue. Implémenter un handler pour cet événement afin de notifier l'utilisateur ou libérer le stock réservé.",
     "Ne jamais fulfiller une commande sur la base du webhook seul. Appeler verify_payment (GET /v1/checkout/sessions/{id}) pour confirmer côté serveur — le payload webhook peut être forgé.",
     "Répondre HTTP 200 immédiatement et traiter de façon asynchrone. Wave retry pendant 3 jours si votre endpoint ne répond pas dans les 5 secondes.",
     "Implémenter l'idempotence via event.id — Wave peut livrer le même événement plusieurs fois. Vérifier que la commande n'est pas déjà fulfillée avant d'agir.",


### PR DESCRIPTION
## Summary

- 7 capabilities Wave : `create_checkout_session`, `verify_payment`, `webhook_payment_completed`, `send_payout`, `get_balance`, `verify_recipient`, `get_transactions`
- Pays couverts : Sénégal, Côte d'Ivoire, Mali, Guinée, Ouganda (XOF, GNF, UGX)
- Doc source : https://docs.wave.com/checkout · https://docs.wave.com/payout · https://docs.wave.com/balance-api · https://docs.wave.com/webhook

## Gotchas documentés

- `wave_launch_url` doit être ouvert dans le navigateur natif, jamais dans une WebView
- Idempotency-Key obligatoire sur `send_payout` — sans elle, un retry réseau peut créer un doublon
- Vérification HMAC-SHA256 sur `webhook_payment_completed` avec raw body (pas le JSON parsé)
- `verify_recipient` : limite 30 appels / 5 min par numéro, blocage 60 min au-delà
- Pas de sandbox — tous les appels touchent la production

## Test plan

- [x] `npm run validate` — 24/24 specs passent, 0 erreur
- [ ] Vérifier les canonical_examples sur un vrai compte Wave Business une fois l'accès obtenu
- [ ] Passer les specs de `compliant` à `verified` après validation sur un exemple dans afrotools/examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)