### PR TITLE
chore(ci): fix CodeQL permissions and upgrade actions to Node.js 24

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,13 +16,14 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -38,10 +39,10 @@ jobs:
         run: node scripts/validate.js --security-only
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,10 +10,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Summary

- Add `security-events: write` permission — requis pour que CodeQL uploade les résultats SARIF
- Upgrade `actions/checkout` v4 → v6 (Node.js 24)
- Upgrade `actions/setup-node` v4 → v6 (Node.js 24)
- Upgrade `github/codeql-action` v3 → v4 (Node.js 24)

## Test Plan
- [ ] Security scan passe sur main
- [ ] Plus de warnings Node.js 20 dans les logs Actions