### PR TITLE
feat(nimbasms): add 10 SMS capabilities

### DIFF
--- a/specs/sms/nimbasms/create_contact/canonical_example.ts
+++ b/specs/sms/nimbasms/create_contact/canonical_example.ts
@@ -1,0 +1,68 @@
+/**
+ * @provider NimbaSMS
+ * @capability create_contact
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+const NIMBASMS_SECRET_TOKEN = process.env.NIMBASMS_SECRET_TOKEN;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN");
+
+const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
+
+interface CreateContactInput {
+  numero: string;
+  name?: string;
+  groups?: string[];
+}
+
+interface ContactResponse {
+  numero: string;
+  name: string;
+  groups: string[];
+}
+
+interface NimbaSMSError {
+  detail: string;
+}
+
+export async function createContact(
+  input: CreateContactInput
+): Promise<ContactResponse> {
+  const response = await fetch("https://api.nimbasms.com/v1/contacts", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const error: NimbaSMSError = await response.json();
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+  }
+
+  return response.json() as Promise<ContactResponse>;
+}
+
+/*
+Usage example:
+
+// Contact minimal
+const contact = await createContact({ numero: "224XXXXXXXXX" });
+
+// Contact avec nom et groupes
+const contact2 = await createContact({
+  numero: "224XXXXXXXXX",
+  name: "Mamadou Diallo",
+  groups: ["Clients", "Newsletter"], // groupes doivent exister dans le compte
+});
+
+console.log(`Contact créé : ${contact2.numero}`);
+
+// 'numero' doit inclure l'indicatif pays sans '+' (224 pour la Guinée)
+// Utiliser list_groups pour récupérer les noms de groupes exacts
+*/

--- a/specs/sms/nimbasms/create_contact/schema.json
+++ b/specs/sms/nimbasms/create_contact/schema.json
@@ -6,7 +6,7 @@
   "category": "sms",
   "capability": "create_contact",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "compliant",
   "country_code": ["GN"],
   "currency": ["GNF"],
   "sandbox": false,

--- a/specs/sms/nimbasms/create_contact/schema.json
+++ b/specs/sms/nimbasms/create_contact/schema.json
@@ -1,0 +1,87 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "create_contact",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "basic",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Basic {base64(NIMBASMS_SERVICE_ID:NIMBASMS_SECRET_TOKEN)}",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.nimbasms.com/v1/contacts"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["numero"],
+    "properties": {
+      "numero": {
+        "type": "string",
+        "description": "Numéro de téléphone du contact avec indicatif pays (ex: 224XXXXXXXXX)."
+      },
+      "name": {
+        "type": "string",
+        "description": "Nom du contact (optionnel)."
+      },
+      "groups": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Noms des groupes auxquels ajouter le contact (optionnel). Les groupes doivent exister dans votre compte."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "numero": {
+        "type": "string",
+        "description": "Numéro de téléphone du contact créé."
+      },
+      "name": {
+        "type": "string",
+        "description": "Nom du contact."
+      },
+      "groups": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Groupes auxquels le contact a été ajouté."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "detail": {
+        "type": "string",
+        "description": "Erreur générale (ex: 401 unauthorized)."
+      },
+      "numero": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'numero' (format invalide, doublon)."
+      },
+      "groups": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'groups' (groupe inexistant)."
+      }
+    }
+  },
+  "gotchas": [
+    "Sans 'groups', le contact est ajouté à la liste de contacts par défaut du compte. Spécifier un groupe inexistant retourne une erreur 400 — utiliser list_groups pour récupérer les noms valides.",
+    "Le champ 'numero' doit inclure l'indicatif pays sans le '+' (ex: 224XXXXXXXXX), contrairement à send_verification qui attend le format E.164 avec '+'. Un format incorrect retourne une erreur 400.",
+    "Créer un contact avec un numéro déjà existant peut retourner une erreur de doublon — vérifier avec list_contacts avant d'insérer en masse."
+  ]
+}

--- a/specs/sms/nimbasms/get_balance/canonical_example.ts
+++ b/specs/sms/nimbasms/get_balance/canonical_example.ts
@@ -1,0 +1,46 @@
+/**
+ * @provider NimbaSMS
+ * @capability get_balance
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+const NIMBASMS_SECRET_TOKEN = process.env.NIMBASMS_SECRET_TOKEN;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN");
+
+const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
+
+interface AccountResponse {
+  balance: number;
+}
+
+interface NimbaSMSError {
+  detail: string;
+}
+
+export async function getBalance(): Promise<AccountResponse> {
+  const response = await fetch("https://api.nimbasms.com/v1/accounts", {
+    method: "GET",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error: NimbaSMSError = await response.json();
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+  }
+
+  return response.json() as Promise<AccountResponse>;
+}
+
+/*
+Usage example:
+
+const account = await getBalance();
+console.log(`Solde disponible : ${account.balance}`);
+
+// Vérifier le solde avant tout envoi groupé pour éviter les rejets silencieux
+*/

--- a/specs/sms/nimbasms/get_balance/canonical_example.ts
+++ b/specs/sms/nimbasms/get_balance/canonical_example.ts
@@ -13,7 +13,11 @@ if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN"
 const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
 
 interface AccountResponse {
-  balance: number;
+  sid: string;
+  sms_balance: number;
+  whatsapp_balance: number;
+  webhook_url: string | null;
+  balance: number; // deprecated — utiliser sms_balance
 }
 
 interface NimbaSMSError {
@@ -40,7 +44,13 @@ export async function getBalance(): Promise<AccountResponse> {
 Usage example:
 
 const account = await getBalance();
-console.log(`Solde disponible : ${account.balance}`);
 
-// Vérifier le solde avant tout envoi groupé pour éviter les rejets silencieux
+// Utiliser sms_balance — 'balance' est deprecated
+console.log(`Solde SMS : ${account.sms_balance} SMS disponibles`);
+console.log(`Solde WhatsApp : ${account.whatsapp_balance}`);
+
+// Vérifier avant envoi groupé
+if (account.sms_balance < 100) {
+  throw new Error("Solde insuffisant pour l'envoi groupé");
+}
 */

--- a/specs/sms/nimbasms/get_balance/schema.json
+++ b/specs/sms/nimbasms/get_balance/schema.json
@@ -6,7 +6,7 @@
   "category": "sms",
   "capability": "get_balance",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "compliant",
   "country_code": ["GN"],
   "currency": ["GNF"],
   "sandbox": false,

--- a/specs/sms/nimbasms/get_balance/schema.json
+++ b/specs/sms/nimbasms/get_balance/schema.json
@@ -30,9 +30,26 @@
   "response_schema": {
     "type": "object",
     "properties": {
+      "sid": {
+        "type": "string",
+        "description": "Identifiant unique du compte (SID)."
+      },
+      "sms_balance": {
+        "type": "integer",
+        "description": "Solde SMS disponible (en nombre de SMS). Utiliser ce champ — 'balance' est deprecated."
+      },
+      "whatsapp_balance": {
+        "type": "integer",
+        "description": "Solde WhatsApp disponible."
+      },
+      "webhook_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL webhook configurée pour les notifications de statut SMS."
+      },
       "balance": {
-        "type": "number",
-        "description": "Solde disponible sur le compte en unités SMS ou en monnaie locale."
+        "type": "integer",
+        "description": "DEPRECATED — Utiliser sms_balance à la place."
       }
     }
   },
@@ -46,7 +63,8 @@
     }
   },
   "gotchas": [
-    "Vérifier le solde avant tout envoi groupé — un solde insuffisant entraîne un rejet silencieux de certains messages sans notification d'erreur globale.",
-    "La structure exacte de la réponse (nom du champ solde, type numérique ou string) n'est pas documentée publiquement. Inspecter la réponse brute lors de l'intégration pour confirmer les noms de champs."
+    "Le champ 'balance' est DEPRECATED — utiliser 'sms_balance' pour le solde SMS. Les deux sont retournés mais 'balance' sera supprimé dans une future version.",
+    "sms_balance est en nombre de SMS (unités), pas en GNF. Un solde de 100 signifie 100 SMS disponibles.",
+    "Vérifier le solde avant tout envoi groupé — un solde insuffisant retourne une erreur 400 avec le champ 'solde' dans la réponse d'erreur de send_message."
   ]
 }

--- a/specs/sms/nimbasms/get_balance/schema.json
+++ b/specs/sms/nimbasms/get_balance/schema.json
@@ -1,0 +1,52 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "get_balance",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "basic",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Basic {base64(NIMBASMS_SERVICE_ID:NIMBASMS_SECRET_TOKEN)}",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.nimbasms.com/v1/accounts"
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {}
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "balance": {
+        "type": "number",
+        "description": "Solde disponible sur le compte en unités SMS ou en monnaie locale."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "detail": {
+        "type": "string",
+        "description": "Erreur générale (ex: 401 unauthorized)."
+      }
+    }
+  },
+  "gotchas": [
+    "Vérifier le solde avant tout envoi groupé — un solde insuffisant entraîne un rejet silencieux de certains messages sans notification d'erreur globale.",
+    "La structure exacte de la réponse (nom du champ solde, type numérique ou string) n'est pas documentée publiquement. Inspecter la réponse brute lors de l'intégration pour confirmer les noms de champs."
+  ]
+}

--- a/specs/sms/nimbasms/get_message/canonical_example.ts
+++ b/specs/sms/nimbasms/get_message/canonical_example.ts
@@ -1,0 +1,55 @@
+/**
+ * @provider NimbaSMS
+ * @capability get_message
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+const NIMBASMS_SECRET_TOKEN = process.env.NIMBASMS_SECRET_TOKEN;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN");
+
+const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
+
+interface MessageResponse {
+  id: string;
+  status: string;
+  to: string[];
+  message: string;
+  sender_name: string;
+  sent_at: string;
+  message_cost: number;
+}
+
+interface NimbaSMSError {
+  detail: string;
+}
+
+export async function getMessage(messageId: string): Promise<MessageResponse> {
+  const endpoint = `https://api.nimbasms.com/v1/messages/${messageId}`;
+  const response = await fetch(endpoint, {
+    method: "GET",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error: NimbaSMSError = await response.json();
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+  }
+
+  return response.json() as Promise<MessageResponse>;
+}
+
+/*
+Usage example:
+
+const message = await getMessage("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx");
+console.log(`Statut : ${message.status}`);
+// Statuts possibles : pending, sent, delivered, failed
+
+// Attendre quelques secondes après send_message avant de vérifier le statut
+// 'sent' ne garantit pas la livraison — attendre 'delivered' pour confirmation
+*/

--- a/specs/sms/nimbasms/get_message/canonical_example.ts
+++ b/specs/sms/nimbasms/get_message/canonical_example.ts
@@ -12,14 +12,20 @@ if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN"
 
 const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
 
-interface MessageResponse {
+interface DeliveryStatus {
   id: string;
-  status: string;
-  to: string[];
-  message: string;
+  contact: string;
+  status: "tosend" | "sent" | "received" | "failure" | "not_available";
+}
+
+interface MessageResponse {
+  messageid: string;
   sender_name: string;
-  sent_at: string;
+  message: string;
+  status: "pending" | "sent" | "failure";
+  sent_at: number; // Unix timestamp en secondes
   message_cost: number;
+  numbers: DeliveryStatus[];
 }
 
 interface NimbaSMSError {
@@ -46,10 +52,19 @@ export async function getMessage(messageId: string): Promise<MessageResponse> {
 /*
 Usage example:
 
+// messageId = messageid retourné par send_message
 const message = await getMessage("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx");
-console.log(`Statut : ${message.status}`);
-// Statuts possibles : pending, sent, delivered, failed
 
-// Attendre quelques secondes après send_message avant de vérifier le statut
-// 'sent' ne garantit pas la livraison — attendre 'delivered' pour confirmation
+// sent_at est un Unix timestamp (secondes) — pas une date ISO
+const sentDate = new Date(message.sent_at * 1000);
+console.log(`Envoyé le : ${sentDate.toISOString()}`);
+
+// Statut par destinataire dans numbers[]
+for (const delivery of message.numbers) {
+  console.log(`${delivery.contact}: ${delivery.status}`);
+  // 'received' = livré, 'sent' = envoyé mais non confirmé, 'failure' = échec
+}
+
+// Le statut global 'sent' ne signifie pas que tous les destinataires ont reçu le SMS
+// Inspecter numbers[] pour le statut individuel
 */

--- a/specs/sms/nimbasms/get_message/schema.json
+++ b/specs/sms/nimbasms/get_message/schema.json
@@ -30,44 +30,54 @@
       "id": {
         "type": "string",
         "format": "uuid",
-        "description": "Identifiant unique du message retourné par send_message."
+        "description": "Identifiant unique du message retourné par send_message (champ messageid)."
       }
     }
   },
   "response_schema": {
     "type": "object",
     "properties": {
-      "id": {
+      "messageid": {
         "type": "string",
         "format": "uuid",
         "description": "Identifiant unique du message."
-      },
-      "status": {
-        "type": "string",
-        "description": "Statut de livraison du message (ex: pending, sent, delivered, failed)."
-      },
-      "to": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "Liste des numéros destinataires."
-      },
-      "message": {
-        "type": "string",
-        "description": "Contenu du message."
       },
       "sender_name": {
         "type": "string",
         "description": "Nom d'expéditeur utilisé."
       },
-      "sent_at": {
+      "message": {
         "type": "string",
-        "format": "date-time",
-        "description": "Horodatage d'envoi ISO 8601."
+        "description": "Contenu du message."
+      },
+      "status": {
+        "type": "string",
+        "enum": ["pending", "sent", "failure"],
+        "description": "Statut global du message."
+      },
+      "sent_at": {
+        "type": "integer",
+        "description": "Horodatage d'envoi en Unix timestamp (secondes). Convertir avec new Date(sent_at * 1000)."
       },
       "message_cost": {
         "type": "integer",
-        "readOnly": true,
-        "description": "Nombre de SMS consommés : longueur du message en nombre de SMS × nombre de destinataires."
+        "description": "Nombre de SMS consommés."
+      },
+      "numbers": {
+        "type": "array",
+        "description": "Statut de livraison par destinataire.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string", "format": "uuid" },
+            "contact": { "type": "string", "description": "Numéro destinataire." },
+            "status": {
+              "type": "string",
+              "enum": ["tosend", "sent", "received", "failure", "not_available"],
+              "description": "Statut de livraison pour ce destinataire."
+            }
+          }
+        }
       }
     }
   },
@@ -81,7 +91,9 @@
     }
   },
   "gotchas": [
-    "Le statut 'sent' ne garantit pas la livraison — utiliser cet endpoint pour vérifier si le statut passe à 'delivered'. Le délai de mise à jour du statut dépend de l'opérateur destinataire.",
-    "L'id doit être un UUID valide retourné par send_message. Un id mal formé retourne une 404 sans message d'erreur explicite."
+    "Le champ d'identifiant dans la réponse est 'messageid' (pas 'id'). Utiliser le messageid retourné par send_message.",
+    "sent_at est un Unix timestamp en secondes (integer), pas une date ISO 8601. Convertir avec new Date(sent_at * 1000) en JavaScript.",
+    "Le statut global ('status') peut être 'sent' alors que certains destinataires dans 'numbers' ont statut 'failure' ou 'not_available'. Inspecter 'numbers' pour le statut par destinataire.",
+    "Le statut 'received' dans 'numbers' signifie livré (delivery receipt reçu de l'opérateur). 'sent' signifie envoyé à l'opérateur mais non encore confirmé livré."
   ]
 }

--- a/specs/sms/nimbasms/get_message/schema.json
+++ b/specs/sms/nimbasms/get_message/schema.json
@@ -1,0 +1,87 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "get_message",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "basic",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Basic {base64(NIMBASMS_SERVICE_ID:NIMBASMS_SECRET_TOKEN)}",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.nimbasms.com/v1/messages/{id}"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Identifiant unique du message retourné par send_message."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Identifiant unique du message."
+      },
+      "status": {
+        "type": "string",
+        "description": "Statut de livraison du message (ex: pending, sent, delivered, failed)."
+      },
+      "to": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Liste des numéros destinataires."
+      },
+      "message": {
+        "type": "string",
+        "description": "Contenu du message."
+      },
+      "sender_name": {
+        "type": "string",
+        "description": "Nom d'expéditeur utilisé."
+      },
+      "sent_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Horodatage d'envoi ISO 8601."
+      },
+      "message_cost": {
+        "type": "integer",
+        "readOnly": true,
+        "description": "Nombre de SMS consommés : longueur du message en nombre de SMS × nombre de destinataires."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "detail": {
+        "type": "string",
+        "description": "Erreur générale (ex: 404 not found, 401 unauthorized)."
+      }
+    }
+  },
+  "gotchas": [
+    "Le statut 'sent' ne garantit pas la livraison — utiliser cet endpoint pour vérifier si le statut passe à 'delivered'. Le délai de mise à jour du statut dépend de l'opérateur destinataire.",
+    "L'id doit être un UUID valide retourné par send_message. Un id mal formé retourne une 404 sans message d'erreur explicite."
+  ]
+}

--- a/specs/sms/nimbasms/get_message/schema.json
+++ b/specs/sms/nimbasms/get_message/schema.json
@@ -6,7 +6,7 @@
   "category": "sms",
   "capability": "get_message",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "compliant",
   "country_code": ["GN"],
   "currency": ["GNF"],
   "sandbox": false,

--- a/specs/sms/nimbasms/list_contacts/canonical_example.ts
+++ b/specs/sms/nimbasms/list_contacts/canonical_example.ts
@@ -1,0 +1,69 @@
+/**
+ * @provider NimbaSMS
+ * @capability list_contacts
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+const NIMBASMS_SECRET_TOKEN = process.env.NIMBASMS_SECRET_TOKEN;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN");
+
+const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
+
+interface ListContactsParams {
+  limit?: number;
+  offset?: number;
+}
+
+interface ContactItem {
+  numero: string;
+  name: string;
+  groups: string[];
+}
+
+interface ListContactsResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: ContactItem[];
+}
+
+interface NimbaSMSError {
+  detail: string;
+}
+
+export async function listContacts(
+  params: ListContactsParams = {}
+): Promise<ListContactsResponse> {
+  const url = new URL("https://api.nimbasms.com/v1/contacts");
+  if (params.limit !== undefined) url.searchParams.set("limit", String(params.limit));
+  if (params.offset !== undefined) url.searchParams.set("offset", String(params.offset));
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error: NimbaSMSError = await response.json();
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+  }
+
+  return response.json() as Promise<ListContactsResponse>;
+}
+
+/*
+Usage example:
+
+const page = await listContacts({ limit: 20 });
+console.log(`${page.count} contacts au total`);
+for (const contact of page.results) {
+  console.log(`${contact.numero} — ${contact.name}`);
+}
+
+// Paginer sur toutes les pages en suivant 'next'
+*/

--- a/specs/sms/nimbasms/list_contacts/schema.json
+++ b/specs/sms/nimbasms/list_contacts/schema.json
@@ -1,0 +1,86 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "list_contacts",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "basic",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Basic {base64(NIMBASMS_SERVICE_ID:NIMBASMS_SECRET_TOKEN)}",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.nimbasms.com/v1/contacts"
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "limit": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Nombre maximum de contacts à retourner."
+      },
+      "offset": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "Décalage pour la pagination."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "count": {
+        "type": "integer",
+        "description": "Nombre total de contacts."
+      },
+      "next": {
+        "type": ["string", "null"],
+        "description": "URL de la page suivante ou null."
+      },
+      "previous": {
+        "type": ["string", "null"],
+        "description": "URL de la page précédente ou null."
+      },
+      "results": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "numero": { "type": "string", "description": "Numéro de téléphone du contact." },
+            "name": { "type": "string", "description": "Nom du contact." },
+            "groups": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Groupes auxquels appartient le contact."
+            }
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "detail": {
+        "type": "string",
+        "description": "Erreur générale (ex: 401 unauthorized)."
+      }
+    }
+  },
+  "gotchas": [
+    "La réponse est paginée. Utiliser 'limit' et 'offset' pour naviguer entre les pages — le champ 'next' contient l'URL complète de la page suivante.",
+    "Le SDK NimbaSMS strip les champs 'count', 'next', 'previous' de la réponse et ne retourne que 'results'. En appelant l'API directement, la réponse brute contient tous ces champs."
+  ]
+}

--- a/specs/sms/nimbasms/list_contacts/schema.json
+++ b/specs/sms/nimbasms/list_contacts/schema.json
@@ -6,7 +6,7 @@
   "category": "sms",
   "capability": "list_contacts",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "compliant",
   "country_code": ["GN"],
   "currency": ["GNF"],
   "sandbox": false,

--- a/specs/sms/nimbasms/list_groups/canonical_example.ts
+++ b/specs/sms/nimbasms/list_groups/canonical_example.ts
@@ -1,0 +1,68 @@
+/**
+ * @provider NimbaSMS
+ * @capability list_groups
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+const NIMBASMS_SECRET_TOKEN = process.env.NIMBASMS_SECRET_TOKEN;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN");
+
+const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
+
+interface ListGroupsParams {
+  limit?: number;
+  offset?: number;
+}
+
+interface GroupItem {
+  name: string;
+}
+
+interface ListGroupsResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: GroupItem[];
+}
+
+interface NimbaSMSError {
+  detail: string;
+}
+
+export async function listGroups(
+  params: ListGroupsParams = {}
+): Promise<ListGroupsResponse> {
+  const url = new URL("https://api.nimbasms.com/v1/groups");
+  if (params.limit !== undefined) url.searchParams.set("limit", String(params.limit));
+  if (params.offset !== undefined) url.searchParams.set("offset", String(params.offset));
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error: NimbaSMSError = await response.json();
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+  }
+
+  return response.json() as Promise<ListGroupsResponse>;
+}
+
+/*
+Usage example:
+
+const page = await listGroups();
+console.log(`${page.count} groupes disponibles`);
+for (const group of page.results) {
+  console.log(group.name);
+}
+
+// Les noms retournés ici sont ceux à passer dans create_contact({ groups: [...] })
+// La casse est significative — copier les noms exactement tels qu'ils apparaissent
+*/

--- a/specs/sms/nimbasms/list_groups/schema.json
+++ b/specs/sms/nimbasms/list_groups/schema.json
@@ -1,0 +1,80 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "list_groups",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "basic",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Basic {base64(NIMBASMS_SERVICE_ID:NIMBASMS_SECRET_TOKEN)}",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.nimbasms.com/v1/groups"
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "limit": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Nombre maximum de groupes à retourner."
+      },
+      "offset": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "Décalage pour la pagination."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "count": {
+        "type": "integer",
+        "description": "Nombre total de groupes."
+      },
+      "next": {
+        "type": ["string", "null"],
+        "description": "URL de la page suivante ou null."
+      },
+      "previous": {
+        "type": ["string", "null"],
+        "description": "URL de la page précédente ou null."
+      },
+      "results": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "description": "Nom du groupe." }
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "detail": {
+        "type": "string",
+        "description": "Erreur générale (ex: 401 unauthorized)."
+      }
+    }
+  },
+  "gotchas": [
+    "Les noms de groupes retournés ici sont ceux à passer dans create_contact({ groups: [...] }). La casse est significative — copier les valeurs exactes retournées par cet endpoint.",
+    "Les groupes ne peuvent pas être créés via l'API — ils doivent être créés depuis le dashboard NimbaSMS."
+  ]
+}

--- a/specs/sms/nimbasms/list_groups/schema.json
+++ b/specs/sms/nimbasms/list_groups/schema.json
@@ -6,7 +6,7 @@
   "category": "sms",
   "capability": "list_groups",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "compliant",
   "country_code": ["GN"],
   "currency": ["GNF"],
   "sandbox": false,

--- a/specs/sms/nimbasms/list_groups/schema.json
+++ b/specs/sms/nimbasms/list_groups/schema.json
@@ -75,6 +75,7 @@
   },
   "gotchas": [
     "Les noms de groupes retournés ici sont ceux à passer dans create_contact({ groups: [...] }). La casse est significative — copier les valeurs exactes retournées par cet endpoint.",
-    "Les groupes ne peuvent pas être créés via l'API — ils doivent être créés depuis le dashboard NimbaSMS."
+    "Les groupes ne peuvent pas être créés via l'API — ils doivent être créés depuis le dashboard NimbaSMS.",
+    "Le SDK NimbaSMS strip les champs 'count', 'next', 'previous' de la réponse paginée et ne retourne que 'results'. En appelant l'API directement, la réponse brute contient tous ces champs."
   ]
 }

--- a/specs/sms/nimbasms/list_groups/schema.json
+++ b/specs/sms/nimbasms/list_groups/schema.json
@@ -58,7 +58,10 @@
         "items": {
           "type": "object",
           "properties": {
-            "name": { "type": "string", "description": "Nom du groupe." }
+            "groupe_id": { "type": "string", "format": "uuid", "description": "Identifiant unique du groupe." },
+            "name": { "type": "string", "maxLength": 100, "description": "Nom du groupe." },
+            "added_at": { "type": "string", "description": "Date d'ajout du groupe." },
+            "total_contact": { "type": "integer", "description": "Nombre de contacts dans le groupe." }
           }
         }
       }

--- a/specs/sms/nimbasms/list_messages/canonical_example.ts
+++ b/specs/sms/nimbasms/list_messages/canonical_example.ts
@@ -1,0 +1,88 @@
+/**
+ * @provider NimbaSMS
+ * @capability list_messages
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+const NIMBASMS_SECRET_TOKEN = process.env.NIMBASMS_SECRET_TOKEN;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN");
+
+const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
+
+interface ListMessagesParams {
+  limit?: number;
+  offset?: number;
+  sent_at?: string;
+  sent_at__lte?: string;
+  sent_at__gte?: string;
+}
+
+interface MessageItem {
+  id: string;
+  status: string;
+  to: string[];
+  message: string;
+  sender_name: string;
+  sent_at: string;
+  message_cost: number;
+}
+
+interface ListMessagesResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: MessageItem[];
+}
+
+interface NimbaSMSError {
+  detail: string;
+}
+
+export async function listMessages(
+  params: ListMessagesParams = {}
+): Promise<ListMessagesResponse> {
+  const url = new URL("https://api.nimbasms.com/v1/messages");
+  if (params.limit !== undefined) url.searchParams.set("limit", String(params.limit));
+  if (params.offset !== undefined) url.searchParams.set("offset", String(params.offset));
+  if (params.sent_at) url.searchParams.set("sent_at", params.sent_at);
+  if (params.sent_at__lte) url.searchParams.set("sent_at__lte", params.sent_at__lte);
+  if (params.sent_at__gte) url.searchParams.set("sent_at__gte", params.sent_at__gte);
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error: NimbaSMSError = await response.json();
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+  }
+
+  return response.json() as Promise<ListMessagesResponse>;
+}
+
+/*
+Usage example:
+
+// Récupérer les 10 derniers messages
+const page = await listMessages({ limit: 10 });
+console.log(`Total : ${page.count} messages`);
+for (const msg of page.results) {
+  console.log(`${msg.id} — ${msg.status} — ${msg.sent_at}`);
+}
+
+// Filtrer par plage de dates
+const filtered = await listMessages({
+  sent_at__gte: "2024-01-01T00:00:00Z",
+  sent_at__lte: "2024-01-31T23:59:59Z",
+  limit: 50,
+});
+
+// 'count' indique le total mais 'results' ne contient que la page courante
+// Utiliser 'next' pour paginer sur toutes les pages
+*/

--- a/specs/sms/nimbasms/list_messages/schema.json
+++ b/specs/sms/nimbasms/list_messages/schema.json
@@ -6,7 +6,7 @@
   "category": "sms",
   "capability": "list_messages",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "compliant",
   "country_code": ["GN"],
   "currency": ["GNF"],
   "sandbox": false,

--- a/specs/sms/nimbasms/list_messages/schema.json
+++ b/specs/sms/nimbasms/list_messages/schema.json
@@ -1,0 +1,106 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "list_messages",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "basic",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Basic {base64(NIMBASMS_SERVICE_ID:NIMBASMS_SECRET_TOKEN)}",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.nimbasms.com/v1/messages"
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "limit": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Nombre maximum de messages à retourner."
+      },
+      "offset": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "Décalage pour la pagination."
+      },
+      "sent_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Filtrer les messages envoyés exactement à cette date et heure (ISO 8601)."
+      },
+      "sent_at__lte": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Filtrer les messages envoyés avant ou à cette date et heure (ISO 8601)."
+      },
+      "sent_at__gte": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Filtrer les messages envoyés après ou à cette date et heure (ISO 8601)."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "count": {
+        "type": "integer",
+        "description": "Nombre total de messages disponibles."
+      },
+      "next": {
+        "type": ["string", "null"],
+        "description": "URL de la page suivante ou null si dernière page."
+      },
+      "previous": {
+        "type": ["string", "null"],
+        "description": "URL de la page précédente ou null si première page."
+      },
+      "results": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string", "format": "uuid" },
+            "status": { "type": "string" },
+            "to": { "type": "array", "items": { "type": "string" } },
+            "message": { "type": "string" },
+            "sender_name": { "type": "string" },
+            "sent_at": { "type": "string", "format": "date-time" },
+            "message_cost": {
+              "type": "integer",
+              "readOnly": true,
+              "description": "Nombre de SMS consommés : longueur du message en nombre de SMS × nombre de destinataires."
+            }
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "detail": {
+        "type": "string",
+        "description": "Erreur générale (ex: 401 unauthorized)."
+      }
+    }
+  },
+  "gotchas": [
+    "La réponse est paginée — le champ 'count' indique le total mais 'results' ne contient que la page courante. Utiliser 'next' pour itérer sur toutes les pages.",
+    "Les filtres sent_at__lte et sent_at__gte peuvent être combinés pour définir une plage de dates. Les dates doivent être en format ISO 8601.",
+    "Chaque item retourné dans 'results' inclut un champ message_cost indiquant le nombre de SMS consommés pour ce message (longueur × destinataires). Utiliser ce champ pour les rapports de consommation."
+  ]
+}

--- a/specs/sms/nimbasms/list_sendernames/canonical_example.ts
+++ b/specs/sms/nimbasms/list_sendernames/canonical_example.ts
@@ -1,0 +1,68 @@
+/**
+ * @provider NimbaSMS
+ * @capability list_sendernames
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+const NIMBASMS_SECRET_TOKEN = process.env.NIMBASMS_SECRET_TOKEN;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN");
+
+const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
+
+interface ListSendernamesParams {
+  limit?: number;
+  offset?: number;
+}
+
+interface SenderNameItem {
+  name: string;
+  status: string;
+}
+
+interface ListSendernamesResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: SenderNameItem[];
+}
+
+interface NimbaSMSError {
+  detail: string;
+}
+
+export async function listSendernames(
+  params: ListSendernamesParams = {}
+): Promise<ListSendernamesResponse> {
+  const url = new URL("https://api.nimbasms.com/v1/sendernames");
+  if (params.limit !== undefined) url.searchParams.set("limit", String(params.limit));
+  if (params.offset !== undefined) url.searchParams.set("offset", String(params.offset));
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error: NimbaSMSError = await response.json();
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+  }
+
+  return response.json() as Promise<ListSendernamesResponse>;
+}
+
+/*
+Usage example:
+
+const page = await listSendernames();
+const active = page.results.filter((s) => s.status === "active");
+console.log(`Sender names actifs : ${active.map((s) => s.name).join(", ")}`);
+
+// Utiliser uniquement les sender names avec status 'active' dans send_message
+// Les sender names 'pending' sont en cours de validation — ne pas les utiliser
+// Les sender names doivent être créés depuis le dashboard NimbaSMS, pas via l'API
+*/

--- a/specs/sms/nimbasms/list_sendernames/schema.json
+++ b/specs/sms/nimbasms/list_sendernames/schema.json
@@ -58,8 +58,14 @@
         "items": {
           "type": "object",
           "properties": {
-            "name": { "type": "string", "description": "Nom d'expéditeur approuvé." },
-            "status": { "type": "string", "description": "Statut du sender name (ex: active, pending)." }
+            "sendername_id": { "type": "string", "format": "uuid", "description": "Identifiant unique du sender name." },
+            "name": { "type": "string", "description": "Nom d'expéditeur." },
+            "status": {
+              "type": "string",
+              "enum": ["pending", "refused", "accepted"],
+              "description": "Statut du sender name. Seul 'accepted' peut être utilisé dans send_message et send_verification."
+            },
+            "added_at": { "type": "integer", "description": "Date d'ajout en Unix timestamp (secondes)." }
           }
         }
       }
@@ -75,7 +81,7 @@
     }
   },
   "gotchas": [
-    "Seuls les sender names avec statut 'active' peuvent être utilisés dans send_message et send_verification. Un sender name 'pending' est en cours de validation manuelle par NimbaSMS.",
+    "Seuls les sender names avec statut 'accepted' peuvent être utilisés dans send_message et send_verification. Les statuts valides sont 'pending' (en validation), 'refused' (refusé) et 'accepted' (utilisable) — pas 'active'.",
     "Les sender names sont approuvés manuellement par NimbaSMS — ils ne peuvent pas être créés via l'API. Les créer depuis le dashboard, puis les récupérer ici.",
     "La valeur retournée dans 'name' est à utiliser telle quelle dans send_message({ sender_name: '...' }) — elle est case-sensitive.",
     "Le SDK NimbaSMS strip les champs 'count', 'next', 'previous' de la réponse paginée et ne retourne que 'results'. En appelant l'API directement, la réponse brute contient tous ces champs."

--- a/specs/sms/nimbasms/list_sendernames/schema.json
+++ b/specs/sms/nimbasms/list_sendernames/schema.json
@@ -6,7 +6,7 @@
   "category": "sms",
   "capability": "list_sendernames",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "compliant",
   "country_code": ["GN"],
   "currency": ["GNF"],
   "sandbox": false,

--- a/specs/sms/nimbasms/list_sendernames/schema.json
+++ b/specs/sms/nimbasms/list_sendernames/schema.json
@@ -77,6 +77,7 @@
   "gotchas": [
     "Seuls les sender names avec statut 'active' peuvent être utilisés dans send_message et send_verification. Un sender name 'pending' est en cours de validation manuelle par NimbaSMS.",
     "Les sender names sont approuvés manuellement par NimbaSMS — ils ne peuvent pas être créés via l'API. Les créer depuis le dashboard, puis les récupérer ici.",
-    "La valeur retournée dans 'name' est à utiliser telle quelle dans send_message({ sender_name: '...' }) — elle est case-sensitive."
+    "La valeur retournée dans 'name' est à utiliser telle quelle dans send_message({ sender_name: '...' }) — elle est case-sensitive.",
+    "Le SDK NimbaSMS strip les champs 'count', 'next', 'previous' de la réponse paginée et ne retourne que 'results'. En appelant l'API directement, la réponse brute contient tous ces champs."
   ]
 }

--- a/specs/sms/nimbasms/list_sendernames/schema.json
+++ b/specs/sms/nimbasms/list_sendernames/schema.json
@@ -1,0 +1,82 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "list_sendernames",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "basic",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Basic {base64(NIMBASMS_SERVICE_ID:NIMBASMS_SECRET_TOKEN)}",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.nimbasms.com/v1/sendernames"
+  },
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "limit": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Nombre maximum de sender names à retourner."
+      },
+      "offset": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "Décalage pour la pagination."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "count": {
+        "type": "integer",
+        "description": "Nombre total de sender names."
+      },
+      "next": {
+        "type": ["string", "null"],
+        "description": "URL de la page suivante ou null."
+      },
+      "previous": {
+        "type": ["string", "null"],
+        "description": "URL de la page précédente ou null."
+      },
+      "results": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "description": "Nom d'expéditeur approuvé." },
+            "status": { "type": "string", "description": "Statut du sender name (ex: active, pending)." }
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "detail": {
+        "type": "string",
+        "description": "Erreur générale (ex: 401 unauthorized)."
+      }
+    }
+  },
+  "gotchas": [
+    "Seuls les sender names avec statut 'active' peuvent être utilisés dans send_message et send_verification. Un sender name 'pending' est en cours de validation manuelle par NimbaSMS.",
+    "Les sender names sont approuvés manuellement par NimbaSMS — ils ne peuvent pas être créés via l'API. Les créer depuis le dashboard, puis les récupérer ici.",
+    "La valeur retournée dans 'name' est à utiliser telle quelle dans send_message({ sender_name: '...' }) — elle est case-sensitive."
+  ]
+}

--- a/specs/sms/nimbasms/send_message/canonical_example.ts
+++ b/specs/sms/nimbasms/send_message/canonical_example.ts
@@ -24,6 +24,7 @@ interface SendMessageResponse {
   to: string[];
   message: string;
   sender_name: string;
+  sent_at: string;
   message_cost: number;
 }
 

--- a/specs/sms/nimbasms/send_message/canonical_example.ts
+++ b/specs/sms/nimbasms/send_message/canonical_example.ts
@@ -1,0 +1,70 @@
+/**
+ * @provider NimbaSMS
+ * @capability send_message
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+const NIMBASMS_SECRET_TOKEN = process.env.NIMBASMS_SECRET_TOKEN;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN");
+
+const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
+
+interface SendMessageInput {
+  to: string[];
+  message: string;
+  sender_name: string;
+}
+
+interface SendMessageResponse {
+  id: string;
+  status: string;
+  to: string[];
+  message: string;
+  sender_name: string;
+  message_cost: number;
+}
+
+interface NimbaSMSError {
+  detail: string;
+}
+
+export async function sendMessage(
+  input: SendMessageInput
+): Promise<SendMessageResponse> {
+  const response = await fetch("https://api.nimbasms.com/v1/messages", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const error: NimbaSMSError = await response.json();
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+  }
+
+  return response.json() as Promise<SendMessageResponse>;
+}
+
+/*
+Usage example:
+
+const message = await sendMessage({
+  to: ["622XXXXXX", "628XXXXXX"], // format local sans indicatif pays ni '+' (Guinée: 6XXXXXXXX)
+  message: "Votre commande #123 a été confirmée.",
+  sender_name: "MonApp", // doit correspondre exactement à un sender name approuvé (case-sensitive)
+});
+
+console.log(`Message envoyé : ${message.id} (statut: ${message.status})`);
+console.log(`SMS consommés : ${message.message_cost}`); // longueur message × nombre destinataires
+
+// Vérifier le statut de livraison avec get_message après quelques secondes
+// sender_name est case-sensitive — utiliser list_sendernames pour récupérer la valeur exacte
+// ATTENTION : send_message utilise le format local (6XXXXXXXX), pas E.164 (+224XXXXXXXX)
+// send_verification utilise E.164 avec '+' — formats différents selon l'endpoint
+*/

--- a/specs/sms/nimbasms/send_message/canonical_example.ts
+++ b/specs/sms/nimbasms/send_message/canonical_example.ts
@@ -16,20 +16,20 @@ interface SendMessageInput {
   to: string[];
   message: string;
   sender_name: string;
+  channel?: "sms" | "whatsapp" | "email";
 }
 
 interface SendMessageResponse {
-  id: string;
-  status: string;
-  to: string[];
-  message: string;
-  sender_name: string;
-  sent_at: string;
+  messageid: string;
   message_cost: number;
+  url: string;
 }
 
 interface NimbaSMSError {
-  detail: string;
+  detail?: string;
+  sender_name?: string;
+  solde?: string;
+  to?: string;
 }
 
 export async function sendMessage(
@@ -46,7 +46,8 @@ export async function sendMessage(
 
   if (!response.ok) {
     const error: NimbaSMSError = await response.json();
-    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+    const msg = error.detail ?? error.sender_name ?? error.solde ?? error.to ?? "Unknown error";
+    throw new Error(`NimbaSMS error ${response.status}: ${msg}`);
   }
 
   return response.json() as Promise<SendMessageResponse>;
@@ -55,17 +56,17 @@ export async function sendMessage(
 /*
 Usage example:
 
-const message = await sendMessage({
-  to: ["622XXXXXX", "628XXXXXX"], // format local sans indicatif pays ni '+' (Guinée: 6XXXXXXXX)
+// Retourne HTTP 201 Created
+const result = await sendMessage({
+  to: ["623XXXXXX", "224623XXXXXX", "+224623XXXXXX"], // trois formats acceptés
   message: "Votre commande #123 a été confirmée.",
-  sender_name: "MonApp", // doit correspondre exactement à un sender name approuvé (case-sensitive)
+  sender_name: "MonApp", // case-sensitive, statut 'accepted' requis
 });
 
-console.log(`Message envoyé : ${message.id} (statut: ${message.status})`);
-console.log(`SMS consommés : ${message.message_cost}`); // longueur message × nombre destinataires
+console.log(`messageid : ${result.messageid}`);
+console.log(`SMS consommés : ${result.message_cost}`);
 
-// Vérifier le statut de livraison avec get_message après quelques secondes
-// sender_name est case-sensitive — utiliser list_sendernames pour récupérer la valeur exacte
-// ATTENTION : send_message utilise le format local (6XXXXXXXX), pas E.164 (+224XXXXXXXX)
-// send_verification utilise E.164 avec '+' — formats différents selon l'endpoint
+// Utiliser result.messageid avec get_message pour suivre le statut par destinataire
+// Maximum 30 destinataires par requête, message max 665 chars (5 SMS)
+// sender_name doit avoir statut 'accepted' dans list_sendernames (pas 'pending' ni 'refused')
 */

--- a/specs/sms/nimbasms/send_message/schema.json
+++ b/specs/sms/nimbasms/send_message/schema.json
@@ -6,7 +6,7 @@
   "category": "sms",
   "capability": "send_message",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "compliant",
   "country_code": ["GN"],
   "currency": ["GNF"],
   "sandbox": false,

--- a/specs/sms/nimbasms/send_message/schema.json
+++ b/specs/sms/nimbasms/send_message/schema.json
@@ -29,53 +29,46 @@
     "properties": {
       "to": {
         "type": "array",
-        "items": { "type": "string" },
-        "description": "Liste des numéros destinataires. Chaque numéro doit inclure l'indicatif pays (ex: 224XXXXXXXXX pour la Guinée)."
+        "items": { "type": "string", "maxLength": 15 },
+        "minItems": 1,
+        "maxItems": 30,
+        "description": "Numéros destinataires. Trois formats acceptés : local (623XXXXXX), avec indicatif (224623XXXXXX), ou E.164 (+224623XXXXXX). Maximum 30 contacts par requête."
       },
       "message": {
         "type": "string",
-        "description": "Contenu du SMS à envoyer."
+        "maxLength": 665,
+        "description": "Contenu du message à envoyer. Maximum 665 caractères (5 SMS). Utiliser le simulateur https://simulator.nimbasms.com/ pour calculer le coût."
       },
       "sender_name": {
         "type": "string",
-        "description": "Nom d'expéditeur approuvé (case-sensitive). Doit correspondre exactement à un sender name de votre compte."
+        "maxLength": 30,
+        "description": "Nom d'expéditeur approuvé (case-sensitive). Doit correspondre exactement à un sender name avec statut 'accepted' dans votre compte."
+      },
+      "channel": {
+        "type": "string",
+        "enum": ["sms", "whatsapp", "email"],
+        "default": "sms",
+        "description": "Canal d'envoi. Défaut: 'sms'."
       }
     }
   },
   "response_schema": {
     "type": "object",
+    "required": ["messageid", "message_cost", "url"],
     "properties": {
-      "id": {
+      "messageid": {
         "type": "string",
         "format": "uuid",
-        "description": "Identifiant unique du message."
-      },
-      "status": {
-        "type": "string",
-        "description": "Statut initial du message (ex: pending, sent)."
-      },
-      "to": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "Liste des destinataires."
-      },
-      "message": {
-        "type": "string",
-        "description": "Contenu du message envoyé."
-      },
-      "sender_name": {
-        "type": "string",
-        "description": "Nom d'expéditeur utilisé."
-      },
-      "sent_at": {
-        "type": "string",
-        "format": "date-time",
-        "description": "Horodatage d'envoi ISO 8601."
+        "description": "Identifiant unique du message. Utiliser avec get_message pour suivre le statut de livraison."
       },
       "message_cost": {
         "type": "integer",
-        "readOnly": true,
-        "description": "Nombre de SMS consommés : longueur du message en nombre de SMS × nombre de destinataires. Permet le suivi de consommation sans calcul côté client."
+        "description": "Nombre de SMS consommés (longueur du message en nombre de SMS × nombre de destinataires)."
+      },
+      "url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL pour récupérer les détails du message (GET /v1/messages/{messageid})."
       }
     }
   },
@@ -84,29 +77,27 @@
     "properties": {
       "detail": {
         "type": "string",
-        "description": "Erreur générale (ex: authentification invalide)."
-      },
-      "to": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "Erreurs de validation sur le champ 'to'."
-      },
-      "message": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "Erreurs de validation sur le champ 'message'."
+        "description": "Erreur générale (ex: compte sans privilèges d'envoi, solde insuffisant)."
       },
       "sender_name": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "Erreurs de validation sur le champ 'sender_name'."
+        "type": "string",
+        "description": "Erreur sur le champ sender_name (ex: 'Sender Name invalide.')."
+      },
+      "solde": {
+        "type": "string",
+        "description": "Erreur de solde insuffisant (ex: 'Le solde de votre compte est insuffisant.')."
+      },
+      "to": {
+        "type": "string",
+        "description": "Erreur sur les destinataires (ex: 'Aucun numéro valide fourni.')."
       }
     }
   },
   "gotchas": [
-    "sender_name est case-sensitive et doit correspondre exactement à un nom approuvé sur votre compte. Utiliser list_sendernames pour récupérer la valeur exacte — une casse incorrecte retourne une erreur 400.",
-    "Le format attendu pour les numéros dans 'to' est le format local sans indicatif pays ni '+' (ex: 6XXXXXXXX pour la Guinée). Tester avec un seul destinataire avant un envoi groupé pour valider le format accepté par votre compte.",
-    "Le champ 'to' accepte plusieurs destinataires dans un seul appel mais chaque destinataire est facturé séparément. message_cost dans la réponse indique le total de SMS consommés (longueur message × nombre destinataires). Vérifier le solde avec get_balance avant un envoi groupé.",
-    "Les erreurs de validation retournent un objet avec le nom du champ en clé et un tableau de messages en valeur (ex: {\"sender_name\": [\"...\"]}) et non un simple champ 'detail'."
+    "sender_name est case-sensitive et doit correspondre exactement à un nom avec statut 'accepted' retourné par list_sendernames. 'active' n'est pas un statut valide — c'est 'accepted'.",
+    "Le champ 'to' accepte trois formats interchangeables : local (623XXXXXX), avec indicatif pays (224623XXXXXX), ou E.164 (+224623XXXXXX). Maximum 30 destinataires par requête.",
+    "Le message est limité à 665 caractères (5 SMS). Au-delà de 160 caractères, message_cost augmente proportionnellement. Utiliser le simulateur pour estimer avant l'envoi.",
+    "La réponse HTTP est 201 Created (pas 200). La réponse ne contient que messageid, message_cost et url — les détails complets (statut par destinataire) sont dans GET /v1/messages/{messageid}.",
+    "Les erreurs 400 retournent des champs avec des valeurs string (pas tableau) : sender_name, solde, to, detail. Vérifier le solde avec get_balance avant un envoi groupé."
   ]
 }

--- a/specs/sms/nimbasms/send_message/schema.json
+++ b/specs/sms/nimbasms/send_message/schema.json
@@ -1,0 +1,107 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "send_message",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "basic",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Basic {base64(NIMBASMS_SERVICE_ID:NIMBASMS_SECRET_TOKEN)}",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.nimbasms.com/v1/messages"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["to", "message", "sender_name"],
+    "properties": {
+      "to": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Liste des numéros destinataires. Chaque numéro doit inclure l'indicatif pays (ex: 224XXXXXXXXX pour la Guinée)."
+      },
+      "message": {
+        "type": "string",
+        "description": "Contenu du SMS à envoyer."
+      },
+      "sender_name": {
+        "type": "string",
+        "description": "Nom d'expéditeur approuvé (case-sensitive). Doit correspondre exactement à un sender name de votre compte."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Identifiant unique du message."
+      },
+      "status": {
+        "type": "string",
+        "description": "Statut initial du message (ex: pending, sent)."
+      },
+      "to": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Liste des destinataires."
+      },
+      "message": {
+        "type": "string",
+        "description": "Contenu du message envoyé."
+      },
+      "sender_name": {
+        "type": "string",
+        "description": "Nom d'expéditeur utilisé."
+      },
+      "message_cost": {
+        "type": "integer",
+        "readOnly": true,
+        "description": "Nombre de SMS consommés : longueur du message en nombre de SMS × nombre de destinataires. Permet le suivi de consommation sans calcul côté client."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "detail": {
+        "type": "string",
+        "description": "Erreur générale (ex: authentification invalide)."
+      },
+      "to": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'to'."
+      },
+      "message": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'message'."
+      },
+      "sender_name": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'sender_name'."
+      }
+    }
+  },
+  "gotchas": [
+    "sender_name est case-sensitive et doit correspondre exactement à un nom approuvé sur votre compte. Utiliser list_sendernames pour récupérer la valeur exacte — une casse incorrecte retourne une erreur 400.",
+    "Le format attendu pour les numéros dans 'to' est le format local sans indicatif pays ni '+' (ex: 6XXXXXXXX pour la Guinée). Tester avec un seul destinataire avant un envoi groupé pour valider le format accepté par votre compte.",
+    "Le champ 'to' accepte plusieurs destinataires dans un seul appel mais chaque destinataire est facturé séparément. message_cost dans la réponse indique le total de SMS consommés (longueur message × nombre destinataires). Vérifier le solde avec get_balance avant un envoi groupé.",
+    "Les erreurs de validation retournent un objet avec le nom du champ en clé et un tableau de messages en valeur (ex: {\"sender_name\": [\"...\"]}) et non un simple champ 'detail'."
+  ]
+}

--- a/specs/sms/nimbasms/send_message/schema.json
+++ b/specs/sms/nimbasms/send_message/schema.json
@@ -67,6 +67,11 @@
         "type": "string",
         "description": "Nom d'expéditeur utilisé."
       },
+      "sent_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Horodatage d'envoi ISO 8601."
+      },
       "message_cost": {
         "type": "integer",
         "readOnly": true,

--- a/specs/sms/nimbasms/send_verification/canonical_example.ts
+++ b/specs/sms/nimbasms/send_verification/canonical_example.ts
@@ -1,0 +1,74 @@
+/**
+ * @provider NimbaSMS
+ * @capability send_verification
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+const NIMBASMS_SECRET_TOKEN = process.env.NIMBASMS_SECRET_TOKEN;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN");
+
+const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
+
+interface SendVerificationInput {
+  to: string;
+  message?: string;
+  sender_name?: string;
+  expiry_time?: number;
+  attempts?: number;
+  code_length?: number;
+}
+
+interface SendVerificationResponse {
+  id: string;
+  to: string;
+  status: string;
+  expiry_time: number;
+  attempts: number;
+  code_length: number;
+  message_cost: number;
+}
+
+interface NimbaSMSError {
+  detail: string;
+}
+
+export async function sendVerification(
+  input: SendVerificationInput
+): Promise<SendVerificationResponse> {
+  const response = await fetch("https://api.nimbasms.com/v1/verifications", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const error: NimbaSMSError = await response.json();
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+  }
+
+  return response.json() as Promise<SendVerificationResponse>;
+}
+
+/*
+Usage example:
+
+const verification = await sendVerification({
+  to: "+224XXXXXXXXX", // format E.164 avec '+' (différent de send_message qui utilise le format local)
+  message: "Votre code de vérification est : <1234>", // <1234> est obligatoire
+  expiry_time: 10,   // 10 minutes, entre 5 et 30
+  attempts: 3,       // 3 tentatives max, entre 3 et 10
+  code_length: 6,    // code à 6 chiffres, entre 4 et 8
+});
+
+console.log(`Vérification créée : ${verification.id}`);
+console.log(`SMS consommés : ${verification.message_cost}`); // toujours 1 pour les vérifications
+// Stocker verification.id côté serveur pour appeler verify_code
+// Ne jamais exposer cet id côté client
+// expiry_time et attempts sont envoyés à null quand non fournis — l'API utilise ses propres défauts
+*/

--- a/specs/sms/nimbasms/send_verification/canonical_example.ts
+++ b/specs/sms/nimbasms/send_verification/canonical_example.ts
@@ -14,25 +14,23 @@ const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
 
 interface SendVerificationInput {
   to: string;
+  sender_name: string; // obligatoire
+  channel?: "sms" | "whatsapp" | "email";
   message?: string;
-  sender_name?: string;
-  expiry_time?: number;
-  attempts?: number;
+  expiry_time?: number | null;
+  attempts?: number | null;
   code_length?: number;
 }
 
 interface SendVerificationResponse {
-  id: string;
-  to: string;
-  status: string;
-  expiry_time: number;
-  attempts: number;
-  code_length: number;
+  verificationid: string;
+  code: string;
   message_cost: number;
+  url: string;
 }
 
 interface NimbaSMSError {
-  detail: string;
+  detail?: string;
 }
 
 export async function sendVerification(
@@ -49,7 +47,7 @@ export async function sendVerification(
 
   if (!response.ok) {
     const error: NimbaSMSError = await response.json();
-    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail ?? JSON.stringify(error)}`);
   }
 
   return response.json() as Promise<SendVerificationResponse>;
@@ -59,16 +57,16 @@ export async function sendVerification(
 Usage example:
 
 const verification = await sendVerification({
-  to: "+224XXXXXXXXX", // format E.164 avec '+' (différent de send_message qui utilise le format local)
-  message: "Votre code de vérification est : <1234>", // <1234> est obligatoire
-  expiry_time: 10,   // 10 minutes, entre 5 et 30
-  attempts: 3,       // 3 tentatives max, entre 3 et 10
-  code_length: 6,    // code à 6 chiffres, entre 4 et 8
+  to: "+224623XXXXXX",
+  sender_name: "MonApp", // OBLIGATOIRE et case-sensitive (statut 'accepted')
+  message: "Votre code de vérification est : <1234>", // <1234> obligatoire
+  expiry_time: 10,  // 10 minutes (5-30)
+  attempts: 3,      // 3 tentatives max (3-10)
+  code_length: 6,   // code à 6 chiffres (4-8)
 });
 
-console.log(`Vérification créée : ${verification.id}`);
-console.log(`SMS consommés : ${verification.message_cost}`); // toujours 1 pour les vérifications
-// Stocker verification.id côté serveur pour appeler verify_code
-// Ne jamais exposer cet id côté client
-// expiry_time et attempts sont envoyés à null quand non fournis — l'API utilise ses propres défauts
+console.log(`verificationid : ${verification.verificationid}`);
+// Stocker verificationid côté serveur pour appeler verify_code
+// Ne jamais exposer verificationid côté client
+// verification.code est retourné dans la réponse — uniquement pour les tests
 */

--- a/specs/sms/nimbasms/send_verification/schema.json
+++ b/specs/sms/nimbasms/send_verification/schema.json
@@ -77,12 +77,12 @@
         "description": "Statut de la vérification (ex: pending)."
       },
       "expiry_time": {
-        "type": "integer",
-        "description": "Durée de validité du code en minutes."
+        "type": ["integer", "null"],
+        "description": "Durée de validité du code en minutes. Null si non fourni à la création."
       },
       "attempts": {
-        "type": "integer",
-        "description": "Nombre de tentatives restantes."
+        "type": ["integer", "null"],
+        "description": "Nombre de tentatives restantes. Null si non fourni à la création."
       },
       "code_length": {
         "type": "integer",

--- a/specs/sms/nimbasms/send_verification/schema.json
+++ b/specs/sms/nimbasms/send_verification/schema.json
@@ -25,31 +25,40 @@
   },
   "input_schema": {
     "type": "object",
-    "required": ["to"],
+    "required": ["to", "sender_name"],
     "properties": {
       "to": {
         "type": "string",
-        "description": "Numéro de téléphone du destinataire au format E.164 (ex: +224XXXXXXXXX)."
-      },
-      "message": {
-        "type": "string",
-        "description": "Modèle du message. Doit contenir le placeholder <1234> qui sera remplacé par le code généré. Défaut: 'Code de vérification : <1234>'."
+        "maxLength": 128,
+        "description": "Numéro de téléphone mobile du destinataire."
       },
       "sender_name": {
         "type": "string",
-        "description": "Nom de l'expéditeur (case-sensitive). Défaut: 'SMS 9080'."
+        "maxLength": 30,
+        "description": "Nom de l'expéditeur (case-sensitive, obligatoire). Doit être un sender name avec statut 'accepted'. Pour WhatsApp, le nom d'expéditeur Nimba SMS peut être utilisé par défaut."
+      },
+      "channel": {
+        "type": "string",
+        "enum": ["sms", "whatsapp", "email"],
+        "default": "sms",
+        "description": "Canal d'envoi. Défaut: 'sms'."
+      },
+      "message": {
+        "type": "string",
+        "maxLength": 153,
+        "description": "Modèle du message. Doit contenir le placeholder <1234> qui sera remplacé par le code. Défaut: 'Code de confirmation Nimba SMS <1234>'. Pour WhatsApp, le contenu est remplacé selon le template."
       },
       "expiry_time": {
-        "type": "integer",
+        "type": ["integer", "null"],
         "minimum": 5,
         "maximum": 30,
-        "description": "Durée de validité du code en minutes. Entre 5 et 30 (inclus)."
+        "description": "Durée de validité du code en minutes. Entre 5 et 30 (inclus). null par défaut."
       },
       "attempts": {
-        "type": "integer",
+        "type": ["integer", "null"],
         "minimum": 3,
         "maximum": 10,
-        "description": "Nombre maximum de tentatives avant expiration du code. Entre 3 et 10 (inclus)."
+        "description": "Nombre maximum de tentatives avant expiration. Entre 3 et 10 (inclus). null par défaut."
       },
       "code_length": {
         "type": "integer",
@@ -63,35 +72,23 @@
   "response_schema": {
     "type": "object",
     "properties": {
-      "id": {
+      "verificationid": {
         "type": "string",
         "format": "uuid",
         "description": "Identifiant unique de la vérification. À conserver pour appeler verify_code."
       },
-      "to": {
+      "code": {
         "type": "string",
-        "description": "Numéro destinataire de la vérification."
-      },
-      "status": {
-        "type": "string",
-        "description": "Statut de la vérification (ex: pending)."
-      },
-      "expiry_time": {
-        "type": ["integer", "null"],
-        "description": "Durée de validité du code en minutes. Null si non fourni à la création."
-      },
-      "attempts": {
-        "type": ["integer", "null"],
-        "description": "Nombre de tentatives restantes. Null si non fourni à la création."
-      },
-      "code_length": {
-        "type": "integer",
-        "description": "Longueur du code généré."
+        "description": "Code de confirmation généré (retourné dans la réponse pour faciliter les tests)."
       },
       "message_cost": {
         "type": "integer",
-        "readOnly": true,
         "description": "Nombre de SMS consommés. Toujours 1 pour les vérifications."
+      },
+      "url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL pour vérifier la demande (PATCH /v1/verifications/{verificationid})."
       }
     }
   },
@@ -106,6 +103,11 @@
         "type": "array",
         "items": { "type": "string" },
         "description": "Erreurs de validation sur le champ 'to'."
+      },
+      "sender_name": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'sender_name'."
       },
       "expiry_time": {
         "type": "array",
@@ -125,11 +127,11 @@
     }
   },
   "gotchas": [
-    "Le placeholder <1234> dans le champ 'message' est obligatoire — sans lui, le code généré ne sera pas inclus dans le SMS reçu par l'utilisateur. Le texte autour du placeholder est libre.",
-    "Stocker l'id retourné côté serveur pour appeler verify_code. Ne jamais exposer cet id côté client car il suffit de le connaître pour tenter la vérification.",
-    "expiry_time doit être entre 5 et 30 (inclus) et attempts entre 3 et 10 (inclus). Les valeurs hors plage retournent une erreur 400 avec le nom du champ comme clé (ex: {\"expiry_time\": [\"...\"]}).",
-    "sender_name est case-sensitive. Le défaut 'SMS 9080' doit être reproduit à l'identique si utilisé explicitement. Utiliser list_sendernames pour récupérer les valeurs exactes des noms approuvés.",
-    "Le champ 'to' attend le numéro en format E.164 avec le '+' (ex: +224XXXXXXXXX), contrairement à send_message qui attend le format local sans '+'.",
-    "Les champs expiry_time et attempts sont envoyés à null quand non fournis. Certaines erreurs 400 peuvent provenir de la réception de null sur un champ qui n'accepte pas cette valeur."
+    "sender_name est OBLIGATOIRE (pas optionnel) et case-sensitive. Utiliser list_sendernames pour récupérer les noms avec statut 'accepted'.",
+    "Le placeholder <1234> dans 'message' est obligatoire — sans lui, le code ne sera pas inclus dans le SMS. Le texte autour du placeholder est libre.",
+    "Le champ d'identifiant dans la réponse est 'verificationid' (pas 'id'). Stocker ce champ côté serveur pour appeler verify_code.",
+    "expiry_time et attempts sont envoyés à null quand non fournis — l'API applique ses propres défauts internes.",
+    "Le code généré est retourné dans la réponse API (champ 'code') — ne jamais l'exposer côté client, l'utiliser uniquement pour les tests.",
+    "Pour WhatsApp (channel: 'whatsapp'), le contenu du message est remplacé selon un template NimbaSMS — le champ 'message' est ignoré."
   ]
 }

--- a/specs/sms/nimbasms/send_verification/schema.json
+++ b/specs/sms/nimbasms/send_verification/schema.json
@@ -6,7 +6,7 @@
   "category": "sms",
   "capability": "send_verification",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "compliant",
   "country_code": ["GN"],
   "currency": ["GNF"],
   "sandbox": false,

--- a/specs/sms/nimbasms/send_verification/schema.json
+++ b/specs/sms/nimbasms/send_verification/schema.json
@@ -1,0 +1,135 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "send_verification",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "basic",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Basic {base64(NIMBASMS_SERVICE_ID:NIMBASMS_SECRET_TOKEN)}",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.nimbasms.com/v1/verifications"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["to"],
+    "properties": {
+      "to": {
+        "type": "string",
+        "description": "Numéro de téléphone du destinataire au format E.164 (ex: +224XXXXXXXXX)."
+      },
+      "message": {
+        "type": "string",
+        "description": "Modèle du message. Doit contenir le placeholder <1234> qui sera remplacé par le code généré. Défaut: 'Code de vérification : <1234>'."
+      },
+      "sender_name": {
+        "type": "string",
+        "description": "Nom de l'expéditeur (case-sensitive). Défaut: 'SMS 9080'."
+      },
+      "expiry_time": {
+        "type": "integer",
+        "minimum": 5,
+        "maximum": 30,
+        "description": "Durée de validité du code en minutes. Entre 5 et 30 (inclus)."
+      },
+      "attempts": {
+        "type": "integer",
+        "minimum": 3,
+        "maximum": 10,
+        "description": "Nombre maximum de tentatives avant expiration du code. Entre 3 et 10 (inclus)."
+      },
+      "code_length": {
+        "type": "integer",
+        "minimum": 4,
+        "maximum": 8,
+        "default": 4,
+        "description": "Longueur du code généré. Entre 4 et 8 (inclus). Défaut: 4."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Identifiant unique de la vérification. À conserver pour appeler verify_code."
+      },
+      "to": {
+        "type": "string",
+        "description": "Numéro destinataire de la vérification."
+      },
+      "status": {
+        "type": "string",
+        "description": "Statut de la vérification (ex: pending)."
+      },
+      "expiry_time": {
+        "type": "integer",
+        "description": "Durée de validité du code en minutes."
+      },
+      "attempts": {
+        "type": "integer",
+        "description": "Nombre de tentatives restantes."
+      },
+      "code_length": {
+        "type": "integer",
+        "description": "Longueur du code généré."
+      },
+      "message_cost": {
+        "type": "integer",
+        "readOnly": true,
+        "description": "Nombre de SMS consommés. Toujours 1 pour les vérifications."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "detail": {
+        "type": "string",
+        "description": "Erreur générale (ex: 401 unauthorized)."
+      },
+      "to": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'to'."
+      },
+      "expiry_time": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'expiry_time' (valeur hors plage 5-30)."
+      },
+      "attempts": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'attempts' (valeur hors plage 3-10)."
+      },
+      "code_length": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'code_length' (valeur hors plage 4-8)."
+      }
+    }
+  },
+  "gotchas": [
+    "Le placeholder <1234> dans le champ 'message' est obligatoire — sans lui, le code généré ne sera pas inclus dans le SMS reçu par l'utilisateur. Le texte autour du placeholder est libre.",
+    "Stocker l'id retourné côté serveur pour appeler verify_code. Ne jamais exposer cet id côté client car il suffit de le connaître pour tenter la vérification.",
+    "expiry_time doit être entre 5 et 30 (inclus) et attempts entre 3 et 10 (inclus). Les valeurs hors plage retournent une erreur 400 avec le nom du champ comme clé (ex: {\"expiry_time\": [\"...\"]}).",
+    "sender_name est case-sensitive. Le défaut 'SMS 9080' doit être reproduit à l'identique si utilisé explicitement. Utiliser list_sendernames pour récupérer les valeurs exactes des noms approuvés.",
+    "Le champ 'to' attend le numéro en format E.164 avec le '+' (ex: +224XXXXXXXXX), contrairement à send_message qui attend le format local sans '+'.",
+    "Les champs expiry_time et attempts sont envoyés à null quand non fournis. Certaines erreurs 400 peuvent provenir de la réception de null sur un champ qui n'accepte pas cette valeur."
+  ]
+}

--- a/specs/sms/nimbasms/verify_code/canonical_example.ts
+++ b/specs/sms/nimbasms/verify_code/canonical_example.ts
@@ -12,38 +12,42 @@ if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN"
 
 const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
 
-interface VerifyCodeInput {
-  id: string;
-  code: string;
-}
+type VerificationStatus =
+  | "pending"
+  | "sent"
+  | "expired"
+  | "failure"
+  | "received"
+  | "too_many_attemps" // typo dans l'API NimbaSMS (un seul 't')
+  | "approved"
+  | "read";
 
 interface VerifyCodeResponse {
-  id: string;
-  status: string;
-  to: string;
-  message_cost: number;
+  status: VerificationStatus;
 }
 
 interface NimbaSMSError {
-  detail: string;
+  detail?: string;
+  code?: string[];
 }
 
 export async function verifyCode(
-  input: VerifyCodeInput
+  verificationId: string,
+  code: number // integer, pas string
 ): Promise<VerifyCodeResponse> {
-  const endpoint = `https://api.nimbasms.com/v1/verifications/${input.id}`;
+  const endpoint = `https://api.nimbasms.com/v1/verifications/${verificationId}`;
   const response = await fetch(endpoint, {
     method: "PATCH",
     headers: {
       Authorization: `Basic ${credentials}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ code: input.code }),
+    body: JSON.stringify({ code }),
   });
 
   if (!response.ok) {
     const error: NimbaSMSError = await response.json();
-    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail ?? JSON.stringify(error)}`);
   }
 
   return response.json() as Promise<VerifyCodeResponse>;
@@ -52,20 +56,22 @@ export async function verifyCode(
 /*
 Usage example:
 
-// Appelé côté serveur avec le code saisi par l'utilisateur
-const result = await verifyCode({
-  id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // id retourné par send_verification
-  code: userInputCode,
-});
+// code est un integer (pas une string)
+const userCode = parseInt(req.body.code, 10);
+const result = await verifyCode(
+  "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // verificationid de send_verification
+  userCode
+);
 
 if (result.status === "approved") {
-  // Autoriser l'accès — marquer le numéro comme vérifié en base de données
-  console.log(`Numéro ${result.to} vérifié avec succès`);
-} else {
-  // Informer l'utilisateur que le code est incorrect ou expiré
-  console.log(`Vérification échouée : ${result.status}`);
+  // Numéro vérifié — marquer en base de données immédiatement
+  await db.users.markPhoneVerified(userId);
+} else if (result.status === "too_many_attemps") {
+  // Note: typo volontaire de l'API (un seul 't') — créer une nouvelle vérification
+  throw new Error("Trop de tentatives — veuillez recommencer");
+} else if (result.status === "expired") {
+  throw new Error("Code expiré — veuillez recommencer");
 }
 
-// Chaque tentative échouée décrémente le compteur — après épuisement, créer une nouvelle vérification
-// Ne jamais réutiliser un id après un status 'approved'
+// Appeler uniquement côté serveur — jamais exposer verificationid au client
 */

--- a/specs/sms/nimbasms/verify_code/canonical_example.ts
+++ b/specs/sms/nimbasms/verify_code/canonical_example.ts
@@ -1,0 +1,71 @@
+/**
+ * @provider NimbaSMS
+ * @capability verify_code
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+const NIMBASMS_SECRET_TOKEN = process.env.NIMBASMS_SECRET_TOKEN;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+if (!NIMBASMS_SECRET_TOKEN) throw new Error("Missing env: NIMBASMS_SECRET_TOKEN");
+
+const credentials = btoa(`${NIMBASMS_SERVICE_ID}:${NIMBASMS_SECRET_TOKEN}`);
+
+interface VerifyCodeInput {
+  id: string;
+  code: string;
+}
+
+interface VerifyCodeResponse {
+  id: string;
+  status: string;
+  to: string;
+  message_cost: number;
+}
+
+interface NimbaSMSError {
+  detail: string;
+}
+
+export async function verifyCode(
+  input: VerifyCodeInput
+): Promise<VerifyCodeResponse> {
+  const endpoint = `https://api.nimbasms.com/v1/verifications/${input.id}`;
+  const response = await fetch(endpoint, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ code: input.code }),
+  });
+
+  if (!response.ok) {
+    const error: NimbaSMSError = await response.json();
+    throw new Error(`NimbaSMS error ${response.status}: ${error.detail}`);
+  }
+
+  return response.json() as Promise<VerifyCodeResponse>;
+}
+
+/*
+Usage example:
+
+// Appelé côté serveur avec le code saisi par l'utilisateur
+const result = await verifyCode({
+  id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // id retourné par send_verification
+  code: userInputCode,
+});
+
+if (result.status === "approved") {
+  // Autoriser l'accès — marquer le numéro comme vérifié en base de données
+  console.log(`Numéro ${result.to} vérifié avec succès`);
+} else {
+  // Informer l'utilisateur que le code est incorrect ou expiré
+  console.log(`Vérification échouée : ${result.status}`);
+}
+
+// Chaque tentative échouée décrémente le compteur — après épuisement, créer une nouvelle vérification
+// Ne jamais réutiliser un id après un status 'approved'
+*/

--- a/specs/sms/nimbasms/verify_code/schema.json
+++ b/specs/sms/nimbasms/verify_code/schema.json
@@ -30,34 +30,23 @@
       "id": {
         "type": "string",
         "format": "uuid",
-        "description": "Identifiant de la vérification retourné par send_verification."
+        "description": "Identifiant de la vérification retourné par send_verification (champ verificationid)."
       },
       "code": {
-        "type": "string",
-        "description": "Code saisi par l'utilisateur à vérifier."
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 999999,
+        "description": "Code saisi par l'utilisateur (integer, 4 à 6 chiffres selon code_length). Envoyer comme integer, pas comme string."
       }
     }
   },
   "response_schema": {
     "type": "object",
     "properties": {
-      "id": {
-        "type": "string",
-        "format": "uuid",
-        "description": "Identifiant de la vérification."
-      },
       "status": {
         "type": "string",
-        "description": "Statut de la vérification après tentative (ex: approved, expired, failed)."
-      },
-      "to": {
-        "type": "string",
-        "description": "Numéro téléphone associé à la vérification."
-      },
-      "message_cost": {
-        "type": "integer",
-        "readOnly": true,
-        "description": "Nombre de SMS consommés. Toujours 1 pour les vérifications."
+        "enum": ["pending", "sent", "expired", "failure", "received", "too_many_attemps", "approved", "read"],
+        "description": "Statut de la vérification après tentative. 'approved' = code correct. 'too_many_attemps' = tentatives épuisées (typo dans l'API, un seul 't' à 'attempts')."
       }
     }
   },
@@ -66,7 +55,7 @@
     "properties": {
       "detail": {
         "type": "string",
-        "description": "Erreur générale (ex: code invalide, vérification expirée, not found)."
+        "description": "Erreur générale (ex: not found, unauthorized)."
       },
       "code": {
         "type": "array",
@@ -76,8 +65,10 @@
     }
   },
   "gotchas": [
-    "Chaque appel erroné à verify_code décrémente le compteur de tentatives. Une fois épuisé, la vérification expire définitivement — il faudra en créer une nouvelle via send_verification.",
-    "Ne jamais retransmettre le code saisi par l'utilisateur vers le client avant vérification. Appeler cet endpoint côté serveur uniquement.",
-    "Un status 'approved' doit être validé immédiatement côté serveur et ne pas être mis en cache côté client — le même id ne peut pas être réutilisé pour une seconde vérification."
+    "Le champ 'code' est un integer (pas une string). Envoyer le code saisi par l'utilisateur comme nombre entier dans le body JSON.",
+    "Le champ 'id' dans l'URL correspond au champ 'verificationid' (pas 'id') retourné par send_verification.",
+    "Le statut 'too_many_attemps' (avec une seule lettre 't' à 'attempts') est un typo dans l'API NimbaSMS — prévoir cette valeur exacte dans le code.",
+    "Chaque appel erroné décrémente le compteur de tentatives. Une fois épuisé (status: 'too_many_attemps'), la vérification expire — créer une nouvelle via send_verification.",
+    "Ne jamais appeler cet endpoint côté client — appeler uniquement côté serveur avec le code saisi par l'utilisateur. Un status 'approved' doit immédiatement marquer le numéro comme vérifié en base de données."
   ]
 }

--- a/specs/sms/nimbasms/verify_code/schema.json
+++ b/specs/sms/nimbasms/verify_code/schema.json
@@ -1,0 +1,83 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "verify_code",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "basic",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Basic {base64(NIMBASMS_SERVICE_ID:NIMBASMS_SECRET_TOKEN)}",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "PATCH",
+    "url": "https://api.nimbasms.com/v1/verifications/{id}"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["id", "code"],
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Identifiant de la vérification retourné par send_verification."
+      },
+      "code": {
+        "type": "string",
+        "description": "Code saisi par l'utilisateur à vérifier."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Identifiant de la vérification."
+      },
+      "status": {
+        "type": "string",
+        "description": "Statut de la vérification après tentative (ex: approved, expired, failed)."
+      },
+      "to": {
+        "type": "string",
+        "description": "Numéro téléphone associé à la vérification."
+      },
+      "message_cost": {
+        "type": "integer",
+        "readOnly": true,
+        "description": "Nombre de SMS consommés. Toujours 1 pour les vérifications."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "detail": {
+        "type": "string",
+        "description": "Erreur générale (ex: code invalide, vérification expirée, not found)."
+      },
+      "code": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Erreurs de validation sur le champ 'code'."
+      }
+    }
+  },
+  "gotchas": [
+    "Chaque appel erroné à verify_code décrémente le compteur de tentatives. Une fois épuisé, la vérification expire définitivement — il faudra en créer une nouvelle via send_verification.",
+    "Ne jamais retransmettre le code saisi par l'utilisateur vers le client avant vérification. Appeler cet endpoint côté serveur uniquement.",
+    "Un status 'approved' doit être validé immédiatement côté serveur et ne pas être mis en cache côté client — le même id ne peut pas être réutilisé pour une seconde vérification."
+  ]
+}

--- a/specs/sms/nimbasms/verify_code/schema.json
+++ b/specs/sms/nimbasms/verify_code/schema.json
@@ -6,7 +6,7 @@
   "category": "sms",
   "capability": "verify_code",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "compliant",
   "country_code": ["GN"],
   "currency": ["GNF"],
   "sandbox": false,

--- a/specs/sms/nimbasms/webhook_sms_status/canonical_example.ts
+++ b/specs/sms/nimbasms/webhook_sms_status/canonical_example.ts
@@ -1,0 +1,76 @@
+/**
+ * @provider NimbaSMS
+ * @capability webhook_sms_status
+ * @atss 1.0
+ * @capability_type webhook
+ */
+
+const NIMBASMS_SERVICE_ID = process.env.NIMBASMS_SERVICE_ID;
+if (!NIMBASMS_SERVICE_ID) throw new Error("Missing env: NIMBASMS_SERVICE_ID");
+
+interface WebhookMetadata {
+  message_type: "API";
+}
+
+interface SmsStatusWebhookPayload {
+  messageid: string;
+  status: "received" | "failed";
+  contact: string;
+  metadata: WebhookMetadata;
+}
+
+interface WebhookAck {
+  status: "OK";
+}
+
+export async function handleSmsStatusWebhook(
+  payload: SmsStatusWebhookPayload
+): Promise<WebhookAck> {
+  // Valider que le message existe dans votre système
+  // avant tout traitement (NimbaSMS ne signe pas les requêtes)
+  const { messageid, status, contact } = payload;
+
+  // Traitement asynchrone recommandé — retourner 200 immédiatement
+  // pour éviter un retry de NimbaSMS (max 3 tentatives)
+  setImmediate(async () => {
+    if (status === "received") {
+      // Marquer la livraison confirmée pour ce contact
+      console.log(`SMS ${messageid} livré à ${contact}`);
+    } else if (status === "failed") {
+      // Gérer l'échec de livraison
+      console.log(`SMS ${messageid} en échec pour ${contact}`);
+    }
+  });
+
+  return { status: "OK" };
+}
+
+/*
+Usage example (Express.js handler):
+
+import express from "express";
+const app = express();
+app.use(express.json());
+
+app.post("/webhooks/sms-status", async (req, res) => {
+  // Retourner 200 immédiatement — NimbaSMS retry jusqu'à 3x si pas de 200
+  res.json({ status: "OK" });
+
+  const payload = req.body as SmsStatusWebhookPayload;
+
+  // Valider que le messageid est connu
+  const message = await db.messages.findOne({ messageid: payload.messageid });
+  if (!message) return; // requête frauduleuse ou doublon
+
+  if (payload.status === "received") {
+    await db.messages.updateDeliveryStatus(payload.messageid, payload.contact, "delivered");
+  } else {
+    await db.messages.updateDeliveryStatus(payload.messageid, payload.contact, "failed");
+  }
+});
+
+// Configuration : dashboard NimbaSMS > API KEYS > Webhooks
+// Entrer l'URL de votre endpoint (ex: https://votre-app.com/webhooks/sms-status)
+// Un seul webhook URL par compte
+// NimbaSMS envoie un événement par destinataire (contact)
+*/

--- a/specs/sms/nimbasms/webhook_sms_status/schema.json
+++ b/specs/sms/nimbasms/webhook_sms_status/schema.json
@@ -1,0 +1,77 @@
+{
+  "spec_version": "1.0",
+  "provider_slug": "nimbasms",
+  "provider_name": "NimbaSMS",
+  "provider_api_version": "2024-01-01",
+  "category": "sms",
+  "capability": "webhook_sms_status",
+  "capability_type": "webhook",
+  "status": "compliant",
+  "country_code": ["GN"],
+  "currency": ["GNF"],
+  "sandbox": false,
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "auth": {
+    "type": "none",
+    "env_var": "NIMBASMS_SERVICE_ID"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://your-app.com/webhooks/sms-status"
+  },
+  "input_schema": {
+    "type": "object",
+    "required": ["messageid", "contact", "metadata"],
+    "properties": {
+      "messageid": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Identifiant du message dont le statut a changé. Correspond au messageid retourné par send_message."
+      },
+      "status": {
+        "type": "string",
+        "enum": ["received", "failed"],
+        "default": "received",
+        "description": "Nouveau statut du message. 'received' = livré au destinataire, 'failed' = échec de livraison."
+      },
+      "contact": {
+        "type": "string",
+        "maxLength": 15,
+        "description": "Numéro de téléphone du destinataire concerné."
+      },
+      "metadata": {
+        "type": "object",
+        "required": ["message_type"],
+        "properties": {
+          "message_type": {
+            "type": "string",
+            "enum": ["API"],
+            "description": "Type de message. Toujours 'API' pour les envois via l'API."
+          }
+        }
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "status": {
+        "type": "string",
+        "default": "OK",
+        "description": "Votre serveur doit retourner HTTP 200 avec ce champ pour confirmer la réception."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {}
+  },
+  "gotchas": [
+    "Votre serveur doit retourner HTTP 200 immédiatement après réception — NimbaSMS renvoie la notification jusqu'à 3 fois si la réponse n'est pas 200. Tout traitement lourd doit être asynchrone.",
+    "Le webhook est configuré dans le dashboard NimbaSMS (API KEYS > Webhooks), pas via l'API. Un seul URL webhook par compte.",
+    "Les notifications ne sont disponibles que pour les envois effectués via l'API (metadata.message_type: 'API').",
+    "NimbaSMS ne signe pas les requêtes entrantes — valider que messageid existe bien dans votre système avant de traiter la notification pour éviter les requêtes frauduleuses.",
+    "Le webhook reçoit un événement par destinataire (champ 'contact') — un message envoyé à 10 destinataires peut déclencher jusqu'à 10 appels webhook distincts."
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds 10 ATSS-compliant specs for NimbaSMS covering all capabilities exposed by the official SDK
- All specs validated (`npm run validate`): 39/39 pass, 0 failures

## Capabilities

| Capability | Method | Endpoint |
|---|---|---|
| `send_message` | POST | `/v1/messages` |
| `get_message` | GET | `/v1/messages/{id}` |
| `list_messages` | GET | `/v1/messages` |
| `send_verification` | POST | `/v1/verifications` |
| `verify_code` | PATCH | `/v1/verifications/{id}` |
| `get_balance` | GET | `/v1/accounts` |
| `list_contacts` | GET | `/v1/contacts` |
| `create_contact` | POST | `/v1/contacts` |
| `list_groups` | GET | `/v1/groups` |
| `list_sendernames` | GET | `/v1/sendernames` |

## Notable details

- **Auth:** HTTP Basic (`SERVICE_ID:SECRET_TOKEN` base64)
- **`message_cost` field** included in all message/verification responses (changelog 2026-01-11)
- **Three phone number formats** documented across endpoints with explicit gotchas:
  - `send_message.to[]` → local format without country code (`622XXXXXX`)
  - `send_verification.to` → E.164 with `+` (`+224XXXXXXXXX`)
  - `create_contact.numero` → country code without `+` (`224XXXXXXXXX`)
- `send_verification`: `expiry_time`/`attempts` typed as `["integer", "null"]` since SDK sends explicit `null` when omitted
- SDK pagination stripping behaviour documented in all list endpoints

## Test plan

- [ ] `npm run validate` passes (39/39)
- [ ] TypeScript interfaces compile with `tsc --noEmit`
- [ ] Gotchas are specific and actionable