### PR TITLE
fix(djomy): document X-API-KEY header and gateway-first defaults

### DIFF
--- a/specs/payment/djomy/create_payment/canonical_example.ts
+++ b/specs/payment/djomy/create_payment/canonical_example.ts
@@ -85,12 +85,14 @@ async function getAccessToken(): Promise<string> {
 export async function createPayment(
   input: CreatePaymentInput
 ): Promise<CreatedPaymentData> {
+  const signature = await computeHmacHex(DJOMY_CLIENT_ID!, DJOMY_CLIENT_SECRET!);
   const accessToken = await getAccessToken();
 
   const response = await fetch(`${DJOMY_BASE_URL}/v1/payments`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${accessToken}`,
+      "X-API-KEY": `${DJOMY_CLIENT_ID}:${signature}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({

--- a/specs/payment/djomy/create_payment/schema.json
+++ b/specs/payment/djomy/create_payment/schema.json
@@ -6,7 +6,7 @@
   "category": "payment",
   "capability": "create_payment",
   "capability_type": "synchronous",
-  "status": "verified",
+  "status": "compliant",
   "country_code": [
     "GN"
   ],
@@ -220,9 +220,11 @@
   },
   "gotchas": [
     "Auth requires two steps: (1) compute HMAC-SHA256(clientId, clientSecret) as hex, (2) call POST /v1/auth with header X-API-KEY: clientId:hexSignature to get a Bearer token. Both DJOMY_CLIENT_ID and DJOMY_CLIENT_SECRET env vars are required.",
+    "Every authenticated request requires BOTH headers: Authorization: Bearer {token} AND X-API-KEY: clientId:HMAC. The X-API-KEY must be recomputed for each request. Omitting it returns 401 even with a valid Bearer token.",
     "For Orange Money (OM) and MTN MoMo (MOMO) direct payments, status returns PENDING immediately. The payer receives an OTP from their operator. You must then call confirm_otp with the transactionId and the OTP to complete the payment.",
     "Always verify payment status server-side via verify_payment before fulfilling an order. Never trust only the callback or paymentUrl redirect.",
     "The base URL in this spec is the sandbox (https://sandbox-api.djomy.africa). Replace with the production URL for live payments.",
-    "metadata must be a flat object — no arrays or nested structures. Values can be strings, numbers, or booleans."
+    "metadata must be a flat object — no arrays or nested structures. Values can be strings, numbers, or booleans.",
+    "[VERY IMPORTANT] Unless the user explicitly requests the direct flow (no redirect, OTP collected in your own UI), always use create_payment_gateway instead. create_payment requires you to know the payment method and payer identifier upfront and to handle OTP confirmation yourself. create_payment_gateway delegates everything to the Djomy portal."
   ]
 }

--- a/specs/payment/djomy/create_payment_gateway/canonical_example.ts
+++ b/specs/payment/djomy/create_payment_gateway/canonical_example.ts
@@ -85,12 +85,14 @@ async function getAccessToken(): Promise<string> {
 export async function createPaymentGateway(
   input: CreatePaymentGatewayInput
 ): Promise<CreatedPaymentGatewayData> {
+  const signature = await computeHmacHex(DJOMY_CLIENT_ID!, DJOMY_CLIENT_SECRET!);
   const accessToken = await getAccessToken();
 
   const response = await fetch(`${DJOMY_BASE_URL}/v1/payments/gateway`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${accessToken}`,
+      "X-API-KEY": `${DJOMY_CLIENT_ID}:${signature}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({

--- a/specs/payment/djomy/create_payment_gateway/schema.json
+++ b/specs/payment/djomy/create_payment_gateway/schema.json
@@ -47,7 +47,7 @@
       },
       "payerNumber": {
         "type": "string",
-        "description": "Payer phone number in international format (e.g. 00224623707722). Used to pre-fill the payment portal."
+        "description": "Payer phone number in international format (e.g. 00224623707722). Strictly required by the API — used to pre-fill the payment portal but enforced server-side. Passing an empty string returns 400."
       },
       "allowedPaymentMethods": {
         "type": "array",
@@ -216,6 +216,9 @@
   },
   "gotchas": [
     "Auth requires two steps: (1) compute HMAC-SHA256(clientId, clientSecret) as hex, (2) call POST /v1/auth with header X-API-KEY: clientId:hexSignature to get a Bearer token.",
+    "Every authenticated request requires BOTH headers: Authorization: Bearer {token} AND X-API-KEY: clientId:HMAC. The X-API-KEY must be recomputed for each request. Omitting it returns 401 even with a valid Bearer token.",
+    "payerNumber is strictly enforced by the API despite being described as 'used to pre-fill the portal'. Passing an empty string or omitting it returns 400: 'Le numéro de téléphone du payeur est obligatoire.' Always collect the payer's phone number before calling this endpoint.",
+    "[VERY IMPORTANT] This is the default integration method for Djomy. Unless the user explicitly requests a direct flow with OTP handling in their own UI, always use create_payment_gateway. It delegates payment method selection and OTP handling to the Djomy portal.",
     "The gateway flow handles OTP internally — the payer completes everything on the Djomy portal. Do NOT call confirm_otp after this endpoint. Wait for the webhook instead.",
     "Redirect the payer to redirectUrl immediately after receiving the response. Do not delay — the link may expire.",
     "Always verify payment status server-side via verify_payment before fulfilling an order. The returnUrl redirect is not a proof of payment.",

--- a/specs/payment/djomy/create_payment_link/schema.json
+++ b/specs/payment/djomy/create_payment_link/schema.json
@@ -6,7 +6,7 @@
   "category": "payment",
   "capability": "create_payment_link",
   "capability_type": "synchronous",
-  "status": "verified",
+  "status": "compliant",
   "country_code": [
     "GN"
   ],

--- a/specs/payment/djomy/get_payment_link/schema.json
+++ b/specs/payment/djomy/get_payment_link/schema.json
@@ -6,7 +6,7 @@
   "category": "payment",
   "capability": "get_payment_link",
   "capability_type": "synchronous",
-  "status": "verified",
+  "status": "compliant",
   "country_code": [
     "GN"
   ],


### PR DESCRIPTION
- Add X-API-KEY header to canonical_example.ts for create_payment and create_payment_gateway (required alongside Bearer on every request)
- Add gotcha: every authenticated request requires both Bearer + X-API-KEY
- Add gotcha: payerNumber is strictly enforced in create_payment_gateway
- Add gotcha [VERY IMPORTANT]: use create_payment_gateway by default unless direct flow with OTP handling in own UI is explicitly requested
- Fix payerNumber description to reflect strict server-side enforcement

## Summary

<!-- What does this PR add or change? One sentence. -->

## Spec checklist

<!-- If this PR adds or modifies a spec, complete the checklist below. -->

- [ ] Folder: `specs/{category}/{provider_slug}/{capability}/`
- [ ] Contains exactly `schema.json` + `canonical_example.ts` — nothing else
- [ ] All required ATSS fields present in `schema.json`
- [ ] `gotchas[]` has at least 1 specific, actionable entry
- [ ] `canonical_example.ts` uses native fetch only (no npm imports)
- [ ] `canonical_example.ts` reads credentials from `process.env`
- [ ] `npm run validate` passes with zero errors
- [ ] `status` set to `draft` or `compliant` (never `verified`)

## Type of change

- [ ] New spec
- [ ] Fix (schema field, gotcha, TypeScript error)
- [ ] Docs
- [ ] Tooling / CI
