### PR TITLE
feat(sprint): provider.json, compliant→ready, example_prompt, pipeline cascade

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-changed-report.md
+++ b/.github/ISSUE_TEMPLATE/api-changed-report.md
@@ -1,0 +1,69 @@
+---
+name: API Changed Report
+about: Report that a provider has changed their API — endpoint, auth, fields, or behavior
+title: "[API Change] <Provider> — <what changed>"
+labels: api-change, needs-review
+assignees: ""
+---
+
+## Provider
+
+<!-- Which provider changed? -->
+**Provider:** <!-- e.g. Wave, Paycard, NimbaSMS -->
+**Category:** <!-- payment / sms -->
+
+## What changed
+
+<!-- Check all that apply -->
+- [ ] Endpoint URL changed
+- [ ] Authentication method changed
+- [ ] Request field added / removed / renamed
+- [ ] Response field added / removed / renamed
+- [ ] HTTP status code changed
+- [ ] Error format changed
+- [ ] Behavior changed (without API change)
+- [ ] New capability available
+- [ ] Capability deprecated or removed
+
+## Details
+
+<!-- Describe exactly what changed. Be as specific as possible. -->
+
+**Before:**
+```
+<!-- old behavior / field / value -->
+```
+
+**After:**
+```
+<!-- new behavior / field / value -->
+```
+
+## Source
+
+<!-- Where did you learn about this change? -->
+- [ ] Provider changelog / release notes
+- [ ] Provider official communication (email / Slack)
+- [ ] My integration broke in production
+- [ ] Monitoring alert (automated hash change)
+- [ ] Community report
+
+**Link to source (if applicable):**
+
+## Affected specs
+
+<!-- Which specs in this repo are affected? -->
+- `specs/<category>/<provider>/<capability>/schema.json`
+
+## Impact
+
+<!-- How urgent is this? -->
+- [ ] 🔴 Breaking — integrations using the current spec will fail
+- [ ] 🟠 Partial — some integrations affected, workaround exists
+- [ ] 🟡 Additive — new field / capability, nothing broken yet
+- [ ] 🟢 Minor — documentation update only
+
+---
+
+> Reported by: <!-- your GitHub handle or "automated monitor" -->
+> Date detected: <!-- YYYY-MM-DD -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
       - name: Validate all specs (push to main)
         if: github.event_name == 'push'
         run: npm run validate
+      - name: Trigger MCP redeploy
+        if: github.event_name == 'push' && success()
+        run: |
+          gh api repos/afrotools/mcp/dispatches \
+            --method POST --field event_type=specs-updated
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
 
   # Security scan + CodeQL — only when specs/** changed
   security:

--- a/ATSS.md
+++ b/ATSS.md
@@ -18,16 +18,44 @@ It is not a wrapper. It is not an SDK. It is a declarative description.
 ## Folder structure
 
 ```
-specs/{category}/{provider_slug}/{capability}/
-    schema.json
-    canonical_example.ts
+specs/{category}/{provider_slug}/
+├── provider.json              ← provider-level metadata
+└── {capability}/
+    ├── schema.json            ← capability spec
+    └── canonical_example.ts   ← working TypeScript example
 ```
 
 **category** — `payment` or `sms` (extensible to other categories)
 **provider_slug** — lowercase, no spaces, no dashes (e.g. `paycard`, `wave`, `nimbasms`)
 **capability** — snake_case verb (e.g. `create_payment`, `verify_payment`, `send_otp`)
 
-Every spec folder must contain exactly these two files. Nothing else.
+Every capability folder must contain exactly these two files. Nothing else.
+
+---
+
+## provider.json — required fields
+
+One `provider.json` per provider directory. Carries provider-level metadata migrated from `schema.json`.
+
+```json
+{
+  "slug": "paycard",
+  "name": "Paycard",
+  "category": "payment",
+  "country_code": ["GN"],
+  "description": "Paycard is a Guinean mobile money payment gateway that lets you accept payments via MTN, Orange, and Cellcom mobile wallets.",
+  "example_prompt": "Integrate Paycard to accept mobile money payments in Guinea. Create a payment, extract the operation_reference, and verify the transaction server-side before fulfilling the order."
+}
+```
+
+| Field | Type | Rule |
+|---|---|---|
+| slug | string | Lowercase, no spaces, no dashes — matches the directory name |
+| name | string | Display name of the provider |
+| category | string | `"payment"` or `"sms"` |
+| country_code | string[] | ISO 3166-1 alpha-2 codes — non-empty array |
+| description | string | One-sentence description of the provider for display and MCP context |
+| example_prompt | string | Full-flow usage prompt for AI agents — describes a complete integration scenario |
 
 ---
 
@@ -36,27 +64,26 @@ Every spec folder must contain exactly these two files. Nothing else.
 ```json
 {
   "spec_version": "1.0",
-  "provider_slug": "paycard",
-  "provider_name": "Paycard",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "create_payment",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
+  "status": "ready",
   "currency": ["GNF"],
   "sandbox": false,
   "docs_url": "https://paycard.com/docs/create-payment",
+  "docs_public": false,
   "auth": {
     "type": "api_key",
-    "header": "X-Api-Key",
+    "location": "body",
+    "field": "c",
     "format": "{token}",
     "env_var": "PAYCARD_API_KEY"
   },
   "endpoint": {
     "method": "POST",
-    "url": "https://api.paycard.com/v1/payments"
+    "url": "https://mapaycard.com/epay/create/"
   },
+  "example_prompt": "Initiate a Paycard mobile money payment for a given amount in GNF, extract the operation_reference from the response, and store it immediately before redirecting the user.",
   "input_schema": {},
   "response_schema": {},
   "error_schema": {},
@@ -71,17 +98,23 @@ Every spec folder must contain exactly these two files. Nothing else.
 | Field | Type | Rule |
 |---|---|---|
 | spec_version | string | Always "1.0" |
-| provider_slug | string | Lowercase, no dashes, no spaces |
 | provider_api_version | string | YYYY-MM-DD if provider has no version string |
+| capability | string | snake_case — matches the directory name |
 | capability_type | enum | `synchronous`, `asynchronous`, or `webhook` |
-| status | enum | `draft`, `compliant`, `verified`, `deprecated`, `archived` |
-| country_code | string[] | ISO 3166-1 alpha-2 codes |
+| status | enum | `draft`, `ready`, `verified`, `deprecated`, `archived` |
 | currency | string[] | ISO 4217 codes |
 | sandbox | boolean | true if provider has a sandbox environment |
-| gotchas | string[] | MANDATORY — minimum 1 entry, no exceptions |
+| docs_url | string | Can be `""` — provider has no public docs URL |
+| docs_public | boolean | false if provider does not publish API docs publicly |
+| auth | object | Auth descriptor — see auth variants below |
+| endpoint | object | `{ method, url }` |
+| example_prompt | string | Required for `ready`/`verified` — describes this specific capability usage for AI agents |
 | input_schema | object | JSON Schema describing the request body |
 | response_schema | object | JSON Schema describing the success response |
 | error_schema | object | JSON Schema describing the error response |
+| gotchas | string[] | MANDATORY — minimum 1 entry, no exceptions |
+
+**Fields NOT in schema.json** (migrated to provider.json): `provider_slug`, `provider_name`, `category`, `country_code`.
 
 ### capability_type definitions
 
@@ -137,13 +170,12 @@ interface PaycardError {
 export async function createPayment(
   input: CreatePaymentInput
 ): Promise<CreatePaymentResponse> {
-  const response = await fetch("https://api.paycard.com/v1/payments", {
+  const response = await fetch("https://mapaycard.com/epay/create/", {
     method: "POST",
     headers: {
-      "X-Api-Key": PAYCARD_API_KEY,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(input),
+    body: JSON.stringify({ ...input, c: PAYCARD_API_KEY }),
   });
 
   if (!response.ok) {
@@ -164,7 +196,7 @@ const payment = await createPayment({
   callback_url: "https://myapp.com/callback",
 });
 
-// Redirect user to payment.payment_url
+// Store payment.operation_reference immediately
 // Always verify payment status server-side before fulfilling the order
 */
 ```
@@ -181,21 +213,23 @@ const payment = await createPayment({
 ## Status lifecycle
 
 ```
-draft → compliant → verified → deprecated → archived
+draft → ready → verified → deprecated → archived
 ```
 
-### compliant — criteria
+### ready — criteria
 
 - [ ] `schema.json` passes `npm run validate`
 - [ ] `canonical_example.ts` compiles with `tsc --noEmit`
 - [ ] `gotchas[]` has at least 1 specific, actionable entry
-- [ ] `status` field set to `compliant`
+- [ ] `example_prompt` is non-empty
+- [ ] `provider.json` exists in the parent provider directory
+- [ ] `status` field set to `ready`
 
-A `compliant` spec is visible in the MCP server.
+A `ready` spec is visible in the MCP server.
 
 ### verified — criteria
 
-- [ ] All compliant criteria met
+- [ ] All `ready` criteria met
 - [ ] Working example exists in `afrotools/examples`
 - [ ] Maintainer has set status to `verified`
 
@@ -226,11 +260,11 @@ Gotchas must be: specific, actionable, based on real integration experience.
 
 ## Provider index
 
-| Provider | Category | Slug | Country | Capabilities | Status |
+| Provider | Category | Slug | Countries | Capabilities | Status |
 |---|---|---|---|---|---|
-| Paycard | payment | paycard | GN | create_payment, verify_payment, webhook | In progress |
-| Wave | payment | wave | SN, CI, ML | create_payment, verify_payment, webhook | Planned |
-| LengoPay | payment | lengopay | — | create_payment, verify_payment | Planned |
-| Djomy | payment | djomy | — | create_payment, verify_payment | Planned |
-| Bictorys | payment | bictorys | — | create_payment, verify_payment, webhook | Planned |
-| NimbaSMS | sms | nimbasms | SN | send_otp, send_bulk | Planned |
+| Paycard | payment | paycard | GN | create_payment, verify_payment, webhook_payment_completed | verified (3/3) |
+| Djomy | payment | djomy | GN | confirm_otp, create_payment, create_payment_gateway, create_payment_link, get_payment_link, verify_payment, webhook_payment_completed | ready (4/7 verified) |
+| LengoPay | payment | lengopay | GN | cashin_request, cashin_status, create_payment, get_balance, list_cashin_transactions, list_transactions, verify_payment, webhook_payment_completed | ready (2/8 verified) |
+| Wave | payment | wave | SN, CI, ML, GN, UG, BF, GM, NE, CM, SL, CD | create_checkout_session, create_payout_batch, expire_checkout, get_balance, get_payout, get_transactions, refund_checkout, search_checkouts, send_payout, verify_payment, verify_recipient, webhook_payment_completed | ready (12/12) |
+| NimbaSMS | sms | nimbasms | GN | create_contact, get_balance, get_message, list_contacts, list_groups, list_messages, list_sendernames, send_message, send_verification, verify_code, webhook_sms_status | ready (11/11) |
+| Bictorys | payment | bictorys | — | — | planned |

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -28,20 +28,17 @@ const SPECS_ROOT = path.resolve(__dirname, "../specs");
 
 const REQUIRED_FIELDS = [
   "spec_version",
-  "provider_slug",
-  "provider_name",
   "provider_api_version",
-  "category",
   "capability",
   "capability_type",
   "status",
-  "country_code",
   "currency",
   "sandbox",
   "docs_url",
   "docs_public",
   "auth",
   "endpoint",
+  "example_prompt",
   "input_schema",
   "response_schema",
   "error_schema",
@@ -49,7 +46,7 @@ const REQUIRED_FIELDS = [
 ];
 
 const VALID_CAPABILITY_TYPES = ["synchronous", "asynchronous", "webhook"];
-const VALID_STATUSES = ["draft", "compliant", "verified", "deprecated", "archived"];
+const VALID_STATUSES = ["draft", "ready", "verified", "deprecated", "archived"];
 
 // ---------------------------------------------------------------------------
 // Cross-spec constants
@@ -186,10 +183,43 @@ function validateSchema(specPath) {
     return fail(specPath, `schema.json parse error: ${err.message}`);
   }
 
+  // Validate provider.json exists for this spec
+  const providerDir = path.dirname(specPath);  // specs/category/provider
+  const providerJsonPath = path.join(providerDir, "provider.json");
+  let providerManifest;
+  try {
+    const raw = fs.readFileSync(providerJsonPath, "utf-8");
+    providerManifest = JSON.parse(raw);
+  } catch {
+    return fail(specPath, `Missing provider.json at ${providerJsonPath} — create it with slug, name, category, country_code, description, example_prompt`);
+  }
+
+  // Validate provider.json required fields
+  const PROVIDER_REQUIRED_FIELDS = ["slug", "name", "category", "country_code", "description", "example_prompt"];
+  for (const field of PROVIDER_REQUIRED_FIELDS) {
+    if (!(field in providerManifest)) {
+      return fail(specPath, `provider.json at ${providerJsonPath} missing required field: "${field}"`);
+    }
+  }
+  if (!providerManifest.example_prompt?.trim()) {
+    return fail(specPath, `provider.json example_prompt must be non-empty`);
+  }
+  if (!Array.isArray(providerManifest.country_code) || providerManifest.country_code.length === 0) {
+    return fail(specPath, `provider.json country_code must be a non-empty array`);
+  }
+
   // Required fields present
   for (const field of REQUIRED_FIELDS) {
     if (!(field in schema)) {
       return fail(specPath, `schema.json missing required field: "${field}"`);
+    }
+  }
+
+  // Migrated fields must not appear in schema.json — they belong in provider.json
+  const MIGRATED_FIELDS = ["provider_slug", "provider_name", "category", "country_code"];
+  for (const field of MIGRATED_FIELDS) {
+    if (field in schema) {
+      return fail(specPath, `schema.json must not contain "${field}" — this field has been migrated to provider.json`);
     }
   }
 
@@ -211,9 +241,9 @@ function validateSchema(specPath) {
     return fail(specPath, `status must be one of ${VALID_STATUSES.join("|")}, got "${schema.status}"`);
   }
 
-  // country_code array
-  if (!Array.isArray(schema.country_code)) {
-    return fail(specPath, `country_code must be an array`);
+  // example_prompt must be non-empty for ready/verified specs
+  if ((schema.status === "ready" || schema.status === "verified") && !schema.example_prompt?.trim()) {
+    return fail(specPath, `example_prompt is required and must be non-empty for status "${schema.status}"`);
   }
 
   // currency array
@@ -577,7 +607,8 @@ function runCrossSpecChecks(loadedSchemas) {
   for (const [slug, entries] of loadedSchemas) {
     if (entries.length < 2) continue;
 
-    const ccSigs    = entries.map(({ schema: s }) => JSON.stringify([...s.country_code].sort()));
+    // country_code comes from provider.json (same for all specs of a provider, but check anyway)
+    const ccSigs    = entries.map(({ providerManifest: p }) => JSON.stringify([...p.country_code].sort()));
     const curSigs   = entries.map(({ schema: s }) => JSON.stringify([...s.currency].sort()));
     const apiVers   = entries.map(({ schema: s }) => s.provider_api_version);
     const sandboxes = entries.map(({ schema: s }) => String(s.sandbox));
@@ -587,15 +618,15 @@ function runCrossSpecChecks(loadedSchemas) {
     const majApiVer  = mostCommon(apiVers);
     const majSandbox = mostCommon(sandboxes);
 
-    for (const { specPath, schema } of entries) {
+    for (const { specPath, schema, providerManifest } of entries) {
       const rel = path.relative(SPECS_ROOT, specPath);
       /** @type {string[]} */ const errors = [];
-      const ccSig = JSON.stringify([...schema.country_code].sort());
+      const ccSig = JSON.stringify([...providerManifest.country_code].sort());
       const curSig = JSON.stringify([...schema.currency].sort());
 
       if (ccSig !== majCC) {
         errors.push(
-          `[CROSS-SPEC] country_code: [${[...schema.country_code].sort().join(", ")}] ` +
+          `[CROSS-SPEC] country_code (provider.json): [${[...providerManifest.country_code].sort().join(", ")}] ` +
           `(majoritaire: ${majCC})`
         );
       }
@@ -627,9 +658,11 @@ function runCrossSpecChecks(loadedSchemas) {
   }
 
   // Priority 2: country/currency coherence per spec
+  // country_code is now read from provider.json; pass it alongside schema
   for (const [, entries] of loadedSchemas) {
-    for (const { specPath, schema } of entries) {
-      if (!checkCountryCurrencyCoherence(specPath, schema)) failures++;
+    for (const { specPath, schema, providerManifest } of entries) {
+      // Build a merged view for checkCountryCurrencyCoherence which expects country_code on the object
+      if (!checkCountryCurrencyCoherence(specPath, { ...schema, country_code: providerManifest.country_code })) failures++;
     }
   }
 
@@ -676,9 +709,13 @@ for (const specPath of specs) {
     if (!isChangedMode) {
       try {
         const schema = JSON.parse(fs.readFileSync(path.join(specPath, "schema.json"), "utf8"));
-        const slug = schema.provider_slug;
+        // Derive provider_slug from path: specs/{category}/{provider}/{capability}
+        const slug = path.basename(path.dirname(specPath));
+        // Load provider.json for cross-spec data (already validated above)
+        const providerDir = path.dirname(specPath);
+        const providerManifest = JSON.parse(fs.readFileSync(path.join(providerDir, "provider.json"), "utf-8"));
         if (!loadedSchemas.has(slug)) loadedSchemas.set(slug, []);
-        loadedSchemas.get(slug).push({ specPath, schema });
+        loadedSchemas.get(slug).push({ specPath, schema, providerManifest });
       } catch { /* parse errors already caught by validateSchema */ }
     }
   }

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -33,9 +33,6 @@ const REQUIRED_FIELDS = [
   "capability_type",
   "status",
   "currency",
-  "sandbox",
-  "docs_url",
-  "docs_public",
   "auth",
   "endpoint",
   "example_prompt",
@@ -195,7 +192,7 @@ function validateSchema(specPath) {
   }
 
   // Validate provider.json required fields
-  const PROVIDER_REQUIRED_FIELDS = ["slug", "name", "category", "country_code", "description", "example_prompt"];
+  const PROVIDER_REQUIRED_FIELDS = ["slug", "name", "category", "country_code", "website", "docs_url", "docs_public", "sandbox", "description", "example_prompt"];
   for (const field of PROVIDER_REQUIRED_FIELDS) {
     if (!(field in providerManifest)) {
       return fail(specPath, `provider.json at ${providerJsonPath} missing required field: "${field}"`);
@@ -216,7 +213,7 @@ function validateSchema(specPath) {
   }
 
   // Migrated fields must not appear in schema.json — they belong in provider.json
-  const MIGRATED_FIELDS = ["provider_slug", "provider_name", "category", "country_code"];
+  const MIGRATED_FIELDS = ["provider_slug", "provider_name", "category", "country_code", "sandbox", "docs_url", "docs_public"];
   for (const field of MIGRATED_FIELDS) {
     if (field in schema) {
       return fail(specPath, `schema.json must not contain "${field}" — this field has been migrated to provider.json`);
@@ -249,16 +246,6 @@ function validateSchema(specPath) {
   // currency array
   if (!Array.isArray(schema.currency)) {
     return fail(specPath, `currency must be an array`);
-  }
-
-  // sandbox boolean
-  if (typeof schema.sandbox !== "boolean") {
-    return fail(specPath, `sandbox must be a boolean`);
-  }
-
-  // docs_public boolean
-  if (typeof schema.docs_public !== "boolean") {
-    return fail(specPath, `docs_public must be a boolean`);
   }
 
   // gotchas — minimum 1 entry
@@ -611,7 +598,7 @@ function runCrossSpecChecks(loadedSchemas) {
     const ccSigs    = entries.map(({ providerManifest: p }) => JSON.stringify([...p.country_code].sort()));
     const curSigs   = entries.map(({ schema: s }) => JSON.stringify([...s.currency].sort()));
     const apiVers   = entries.map(({ schema: s }) => s.provider_api_version);
-    const sandboxes = entries.map(({ schema: s }) => String(s.sandbox));
+    const sandboxes = entries.map(({ providerManifest: p }) => String(p.sandbox));
 
     const majCC      = mostCommon(ccSigs);
     const majCur     = mostCommon(curSigs);
@@ -641,9 +628,9 @@ function runCrossSpecChecks(loadedSchemas) {
           `[CROSS-SPEC] provider_api_version: "${schema.provider_api_version}" (majoritaire: "${majApiVer}")`
         );
       }
-      if (String(schema.sandbox) !== majSandbox) {
+      if (String(providerManifest.sandbox) !== majSandbox) {
         errors.push(
-          `[CROSS-SPEC] sandbox: ${schema.sandbox} (majoritaire: ${majSandbox})`
+          `[CROSS-SPEC] sandbox: ${providerManifest.sandbox} (majoritaire: ${majSandbox})`
         );
       }
 

--- a/specs/payment/djomy/confirm_otp/schema.json
+++ b/specs/payment/djomy/confirm_otp/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments/{transactionReference}/confirmOTP"
   },
-  "example_prompt": "My user just entered their OTP to confirm a Djomy mobile money payment — authorize it.",
+  "example_prompt": "Add OTP confirmation to my Djomy payment flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/confirm_otp/schema.json
+++ b/specs/payment/djomy/confirm_otp/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments/{transactionReference}/confirmOTP"
   },
-  "example_prompt": "Write a Node.js function that confirms a Djomy payment OTP. It receives a payment_ref and the otp_code entered by the user, calls the Djomy confirm_otp endpoint, and returns whether the transaction was authorized.",
+  "example_prompt": "My user just entered their OTP to confirm a Djomy mobile money payment — authorize it.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/confirm_otp/schema.json
+++ b/specs/payment/djomy/confirm_otp/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": true,
-  "docs_url": "https://developers.djomy.africa/",
-  "docs_public": true,
   "auth": {
     "type": "bearer",
     "location": "header",

--- a/specs/payment/djomy/confirm_otp/schema.json
+++ b/specs/payment/djomy/confirm_otp/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments/{transactionReference}/confirmOTP"
   },
-  "example_prompt": "Confirm a Djomy payment OTP submitted by the user to authorize the pending mobile money transaction.",
+  "example_prompt": "Write a Node.js function that confirms a Djomy payment OTP. It receives a payment_ref and the otp_code entered by the user, calls the Djomy confirm_otp endpoint, and returns whether the transaction was authorized.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/confirm_otp/schema.json
+++ b/specs/payment/djomy/confirm_otp/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "djomy",
-  "provider_name": "Djomy",
   "provider_api_version": "v1.0",
-  "category": "payment",
   "capability": "confirm_otp",
   "capability_type": "synchronous",
   "status": "verified",
-  "country_code": [
-    "GN"
-  ],
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments/{transactionReference}/confirmOTP"
   },
+  "example_prompt": "Confirm a Djomy payment OTP submitted by the user to authorize the pending mobile money transaction.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment/schema.json
+++ b/specs/payment/djomy/create_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments"
   },
-  "example_prompt": "Write a Node.js function that creates a Djomy mobile money payment. It receives an amount and a customer phone number, calls the Djomy create_payment endpoint, and returns the redirect URL to send the user to.",
+  "example_prompt": "Start a Djomy mobile money payment and redirect my user to complete it.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment/schema.json
+++ b/specs/payment/djomy/create_payment/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "djomy",
-  "provider_name": "Djomy",
   "provider_api_version": "v1.0",
-  "category": "payment",
   "capability": "create_payment",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "GN"
-  ],
+  "status": "ready",
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments"
   },
+  "example_prompt": "Create a Djomy mobile money payment request for a given amount and redirect the user to complete the payment flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment/schema.json
+++ b/specs/payment/djomy/create_payment/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": true,
-  "docs_url": "https://developers.djomy.africa/",
-  "docs_public": true,
   "auth": {
     "type": "bearer",
     "location": "header",

--- a/specs/payment/djomy/create_payment/schema.json
+++ b/specs/payment/djomy/create_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments"
   },
-  "example_prompt": "Create a Djomy mobile money payment request for a given amount and redirect the user to complete the payment flow.",
+  "example_prompt": "Write a Node.js function that creates a Djomy mobile money payment. It receives an amount and a customer phone number, calls the Djomy create_payment endpoint, and returns the redirect URL to send the user to.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment/schema.json
+++ b/specs/payment/djomy/create_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments"
   },
-  "example_prompt": "Start a Djomy mobile money payment and redirect my user to complete it.",
+  "example_prompt": "Add Djomy mobile money payment to my checkout.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment_gateway/schema.json
+++ b/specs/payment/djomy/create_payment_gateway/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "djomy",
-  "provider_name": "Djomy",
   "provider_api_version": "v1.0",
-  "category": "payment",
   "capability": "create_payment_gateway",
   "capability_type": "synchronous",
   "status": "verified",
-  "country_code": [
-    "GN"
-  ],
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments/gateway"
   },
+  "example_prompt": "Integrate the Djomy payment gateway to accept mobile money payments and receive completion events.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment_gateway/schema.json
+++ b/specs/payment/djomy/create_payment_gateway/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments/gateway"
   },
-  "example_prompt": "Set up a Djomy payment gateway integration for my app.",
+  "example_prompt": "Add Djomy as a payment gateway to my app.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment_gateway/schema.json
+++ b/specs/payment/djomy/create_payment_gateway/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments/gateway"
   },
-  "example_prompt": "Integrate the Djomy payment gateway to accept mobile money payments and receive completion events.",
+  "example_prompt": "Write a Node.js function that initializes a Djomy payment gateway with my API credentials and returns the gateway configuration needed for subsequent payment calls.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment_gateway/schema.json
+++ b/specs/payment/djomy/create_payment_gateway/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": true,
-  "docs_url": "https://developers.djomy.africa/",
-  "docs_public": true,
   "auth": {
     "type": "bearer",
     "location": "header",

--- a/specs/payment/djomy/create_payment_gateway/schema.json
+++ b/specs/payment/djomy/create_payment_gateway/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/payments/gateway"
   },
-  "example_prompt": "Write a Node.js function that initializes a Djomy payment gateway with my API credentials and returns the gateway configuration needed for subsequent payment calls.",
+  "example_prompt": "Set up a Djomy payment gateway integration for my app.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment_link/schema.json
+++ b/specs/payment/djomy/create_payment_link/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/links"
   },
-  "example_prompt": "Generate a shareable Djomy payment link for a fixed amount and send it to the customer.",
+  "example_prompt": "Write a Node.js function that generates a shareable Djomy payment link for a fixed amount. It receives a label and price, calls the Djomy create_payment_link endpoint, and returns the URL to share with the customer.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment_link/schema.json
+++ b/specs/payment/djomy/create_payment_link/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/links"
   },
-  "example_prompt": "Generate a Djomy payment link I can send to my customer.",
+  "example_prompt": "Add Djomy payment link to my payment workflow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment_link/schema.json
+++ b/specs/payment/djomy/create_payment_link/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": true,
-  "docs_url": "https://developers.djomy.africa/",
-  "docs_public": true,
   "auth": {
     "type": "bearer",
     "location": "header",

--- a/specs/payment/djomy/create_payment_link/schema.json
+++ b/specs/payment/djomy/create_payment_link/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "djomy",
-  "provider_name": "Djomy",
   "provider_api_version": "v1.0",
-  "category": "payment",
   "capability": "create_payment_link",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "GN"
-  ],
+  "status": "ready",
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/links"
   },
+  "example_prompt": "Generate a shareable Djomy payment link for a fixed amount and send it to the customer.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/create_payment_link/schema.json
+++ b/specs/payment/djomy/create_payment_link/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://sandbox-api.djomy.africa/v1/links"
   },
-  "example_prompt": "Write a Node.js function that generates a shareable Djomy payment link for a fixed amount. It receives a label and price, calls the Djomy create_payment_link endpoint, and returns the URL to share with the customer.",
+  "example_prompt": "Generate a Djomy payment link I can send to my customer.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/get_payment_link/schema.json
+++ b/specs/payment/djomy/get_payment_link/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://sandbox-api.djomy.africa/v1/links/{reference}"
   },
-  "example_prompt": "Check if my customer has paid the Djomy link I sent them.",
+  "example_prompt": "Add a check to see if a customer has paid via the Djomy link I sent them.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/get_payment_link/schema.json
+++ b/specs/payment/djomy/get_payment_link/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://sandbox-api.djomy.africa/v1/links/{reference}"
   },
-  "example_prompt": "Retrieve the current status and details of a Djomy payment link by its ID to check if it has been paid.",
+  "example_prompt": "Write a Node.js function that checks whether a Djomy payment link has been paid. It receives a link ID, calls get_payment_link, and returns the current status.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/get_payment_link/schema.json
+++ b/specs/payment/djomy/get_payment_link/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": true,
-  "docs_url": "https://developers.djomy.africa/",
-  "docs_public": true,
   "auth": {
     "type": "bearer",
     "location": "header",

--- a/specs/payment/djomy/get_payment_link/schema.json
+++ b/specs/payment/djomy/get_payment_link/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://sandbox-api.djomy.africa/v1/links/{reference}"
   },
-  "example_prompt": "Write a Node.js function that checks whether a Djomy payment link has been paid. It receives a link ID, calls get_payment_link, and returns the current status.",
+  "example_prompt": "Check if my customer has paid the Djomy link I sent them.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/get_payment_link/schema.json
+++ b/specs/payment/djomy/get_payment_link/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "djomy",
-  "provider_name": "Djomy",
   "provider_api_version": "v1.0",
-  "category": "payment",
   "capability": "get_payment_link",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "GN"
-  ],
+  "status": "ready",
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "GET",
     "url": "https://sandbox-api.djomy.africa/v1/links/{reference}"
   },
+  "example_prompt": "Retrieve the current status and details of a Djomy payment link by its ID to check if it has been paid.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/provider.json
+++ b/specs/payment/djomy/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["GN"],
   "description": "Djomy is a Guinean payment solution offering payment links, QR code payments, and mobile money integrations via a unified API.",
-  "example_prompt": "I want to add Djomy mobile money payments to my app."
+  "example_prompt": "Add Djomy mobile money payments to my app."
 }

--- a/specs/payment/djomy/provider.json
+++ b/specs/payment/djomy/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["GN"],
   "description": "Djomy is a Guinean payment solution offering payment links, QR code payments, and mobile money integrations via a unified API.",
-  "example_prompt": "Use Djomy to generate a payment link for a fixed amount, send it to the customer, and handle the webhook to confirm payment before delivering the order."
+  "example_prompt": "I want to add Djomy payments to my app. Write a flow that generates a payment link for a fixed amount, sends it to the customer via SMS, and handles the webhook to confirm payment before delivering the order."
 }

--- a/specs/payment/djomy/provider.json
+++ b/specs/payment/djomy/provider.json
@@ -2,7 +2,13 @@
   "slug": "djomy",
   "name": "Djomy",
   "category": "payment",
-  "country_code": ["GN"],
+  "country_code": [
+    "GN"
+  ],
+  "website": "https://djomy.africa",
+  "docs_url": "https://developers.djomy.africa/",
+  "docs_public": true,
+  "sandbox": true,
   "description": "Djomy is a Guinean payment solution offering payment links, QR code payments, and mobile money integrations via a unified API.",
   "example_prompt": "Add Djomy mobile money payments to my app."
 }

--- a/specs/payment/djomy/provider.json
+++ b/specs/payment/djomy/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["GN"],
   "description": "Djomy is a Guinean payment solution offering payment links, QR code payments, and mobile money integrations via a unified API.",
-  "example_prompt": "I want to add Djomy payments to my app. Write a flow that generates a payment link for a fixed amount, sends it to the customer via SMS, and handles the webhook to confirm payment before delivering the order."
+  "example_prompt": "I want to add Djomy mobile money payments to my app."
 }

--- a/specs/payment/djomy/provider.json
+++ b/specs/payment/djomy/provider.json
@@ -1,0 +1,8 @@
+{
+  "slug": "djomy",
+  "name": "Djomy",
+  "category": "payment",
+  "country_code": ["GN"],
+  "description": "Djomy is a Guinean payment solution offering payment links, QR code payments, and mobile money integrations via a unified API.",
+  "example_prompt": "Use Djomy to generate a payment link for a fixed amount, send it to the customer, and handle the webhook to confirm payment before delivering the order."
+}

--- a/specs/payment/djomy/verify_payment/schema.json
+++ b/specs/payment/djomy/verify_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://sandbox-api.djomy.africa/v1/payments/{transactionId}/status"
   },
-  "example_prompt": "Verify the final status of a Djomy payment using its transaction reference before delivering goods or services.",
+  "example_prompt": "Write a Node.js function that verifies a Djomy payment server-side using its transaction reference. Call this before fulfilling an order — do not rely on the redirect URL alone.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/verify_payment/schema.json
+++ b/specs/payment/djomy/verify_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://sandbox-api.djomy.africa/v1/payments/{transactionId}/status"
   },
-  "example_prompt": "Verify server-side that a Djomy payment went through before I fulfill the order.",
+  "example_prompt": "Add server-side Djomy payment verification to my order fulfillment flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/verify_payment/schema.json
+++ b/specs/payment/djomy/verify_payment/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "djomy",
-  "provider_name": "Djomy",
   "provider_api_version": "v1.0",
-  "category": "payment",
   "capability": "verify_payment",
   "capability_type": "synchronous",
   "status": "verified",
-  "country_code": [
-    "GN"
-  ],
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "GET",
     "url": "https://sandbox-api.djomy.africa/v1/payments/{transactionId}/status"
   },
+  "example_prompt": "Verify the final status of a Djomy payment using its transaction reference before delivering goods or services.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/verify_payment/schema.json
+++ b/specs/payment/djomy/verify_payment/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": true,
-  "docs_url": "https://developers.djomy.africa/",
-  "docs_public": true,
   "auth": {
     "type": "bearer",
     "location": "header",

--- a/specs/payment/djomy/verify_payment/schema.json
+++ b/specs/payment/djomy/verify_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://sandbox-api.djomy.africa/v1/payments/{transactionId}/status"
   },
-  "example_prompt": "Write a Node.js function that verifies a Djomy payment server-side using its transaction reference. Call this before fulfilling an order — do not rely on the redirect URL alone.",
+  "example_prompt": "Verify server-side that a Djomy payment went through before I fulfill the order.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/djomy/webhook_payment_completed/schema.json
+++ b/specs/payment/djomy/webhook_payment_completed/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": true,
-  "docs_url": "https://developers.djomy.africa/",
-  "docs_public": true,
   "auth": {
     "type": "none"
   },

--- a/specs/payment/djomy/webhook_payment_completed/schema.json
+++ b/specs/payment/djomy/webhook_payment_completed/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "djomy",
-  "provider_name": "Djomy",
   "provider_api_version": "v1.0",
-  "category": "payment",
   "capability": "webhook_payment_completed",
   "capability_type": "webhook",
   "status": "verified",
-  "country_code": [
-    "GN"
-  ],
   "currency": [
     "GNF"
   ],
@@ -23,6 +17,7 @@
     "method": "POST",
     "url": "{your_webhook_url}"
   },
+  "example_prompt": "Handle an incoming Djomy webhook event confirming payment completion and trigger order fulfillment.",
   "input_schema": {
     "type": "object",
     "description": "Payload Djomy POSTs to your webhook URL when a payment event occurs.",

--- a/specs/payment/djomy/webhook_payment_completed/schema.json
+++ b/specs/payment/djomy/webhook_payment_completed/schema.json
@@ -17,7 +17,7 @@
     "method": "POST",
     "url": "{your_webhook_url}"
   },
-  "example_prompt": "Handle the Djomy webhook that fires when a payment is confirmed.",
+  "example_prompt": "Add a Djomy webhook handler to automatically confirm orders when payment completes.",
   "input_schema": {
     "type": "object",
     "description": "Payload Djomy POSTs to your webhook URL when a payment event occurs.",

--- a/specs/payment/djomy/webhook_payment_completed/schema.json
+++ b/specs/payment/djomy/webhook_payment_completed/schema.json
@@ -17,7 +17,7 @@
     "method": "POST",
     "url": "{your_webhook_url}"
   },
-  "example_prompt": "Handle an incoming Djomy webhook event confirming payment completion and trigger order fulfillment.",
+  "example_prompt": "Write an Express route POST /webhooks/djomy that receives a Djomy payment completion webhook, extracts the payment reference, and triggers order fulfillment.",
   "input_schema": {
     "type": "object",
     "description": "Payload Djomy POSTs to your webhook URL when a payment event occurs.",

--- a/specs/payment/djomy/webhook_payment_completed/schema.json
+++ b/specs/payment/djomy/webhook_payment_completed/schema.json
@@ -17,7 +17,7 @@
     "method": "POST",
     "url": "{your_webhook_url}"
   },
-  "example_prompt": "Write an Express route POST /webhooks/djomy that receives a Djomy payment completion webhook, extracts the payment reference, and triggers order fulfillment.",
+  "example_prompt": "Handle the Djomy webhook that fires when a payment is confirmed.",
   "input_schema": {
     "type": "object",
     "description": "Payload Djomy POSTs to your webhook URL when a payment event occurs.",

--- a/specs/payment/lengopay/cashin_request/schema.json
+++ b/specs/payment/lengopay/cashin_request/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v2/cashin/request"
   },
-  "example_prompt": "Collect a mobile money payment from my customer via LengoPay.",
+  "example_prompt": "Add LengoPay mobile money collection to my checkout.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/cashin_request/schema.json
+++ b/specs/payment/lengopay/cashin_request/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v2/cashin/request"
   },
-  "example_prompt": "Write a Node.js function that initiates a LengoPay cashin to collect a mobile money payment. It receives an amount and a customer phone number, calls cashin_request, and returns the transaction reference for status polling.",
+  "example_prompt": "Collect a mobile money payment from my customer via LengoPay.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/cashin_request/schema.json
+++ b/specs/payment/lengopay/cashin_request/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/lengopay/cashin_request/schema.json
+++ b/specs/payment/lengopay/cashin_request/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "lengopay",
-  "provider_name": "LengoPay",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "cashin_request",
   "capability_type": "asynchronous",
-  "status": "compliant",
-  "country_code": [
-    "GN"
-  ],
+  "status": "ready",
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v2/cashin/request"
   },
+  "example_prompt": "Initiate a LengoPay cashin to collect a mobile money payment from a user's wallet and receive the transaction reference.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/cashin_request/schema.json
+++ b/specs/payment/lengopay/cashin_request/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v2/cashin/request"
   },
-  "example_prompt": "Initiate a LengoPay cashin to collect a mobile money payment from a user's wallet and receive the transaction reference.",
+  "example_prompt": "Write a Node.js function that initiates a LengoPay cashin to collect a mobile money payment. It receives an amount and a customer phone number, calls cashin_request, and returns the transaction reference for status polling.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/cashin_status/schema.json
+++ b/specs/payment/lengopay/cashin_status/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/lengopay/cashin_status/schema.json
+++ b/specs/payment/lengopay/cashin_status/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v2/cashin/transaction"
   },
-  "example_prompt": "Poll the status of a LengoPay cashin transaction using its reference to determine if the payment succeeded or failed.",
+  "example_prompt": "Write a Node.js function that polls the status of a LengoPay cashin using its transaction reference. It returns the final status (success / failed / pending) — call this in a loop after cashin_request until the payment settles.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/cashin_status/schema.json
+++ b/specs/payment/lengopay/cashin_status/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "lengopay",
-  "provider_name": "LengoPay",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "cashin_status",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "GN"
-  ],
+  "status": "ready",
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v2/cashin/transaction"
   },
+  "example_prompt": "Poll the status of a LengoPay cashin transaction using its reference to determine if the payment succeeded or failed.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/cashin_status/schema.json
+++ b/specs/payment/lengopay/cashin_status/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v2/cashin/transaction"
   },
-  "example_prompt": "Check whether my LengoPay cashin request has been paid yet.",
+  "example_prompt": "Add LengoPay payment status polling to my order flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/cashin_status/schema.json
+++ b/specs/payment/lengopay/cashin_status/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v2/cashin/transaction"
   },
-  "example_prompt": "Write a Node.js function that polls the status of a LengoPay cashin using its transaction reference. It returns the final status (success / failed / pending) — call this in a loop after cashin_request until the payment settles.",
+  "example_prompt": "Check whether my LengoPay cashin request has been paid yet.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/create_payment/schema.json
+++ b/specs/payment/lengopay/create_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/payments"
   },
-  "example_prompt": "Create a LengoPay payment request for a given amount and retrieve the payment reference for tracking.",
+  "example_prompt": "Write a Node.js function that creates a LengoPay payment request for a given amount and returns the payment reference and redirect URL.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/create_payment/schema.json
+++ b/specs/payment/lengopay/create_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/payments"
   },
-  "example_prompt": "Write a Node.js function that creates a LengoPay payment request for a given amount and returns the payment reference and redirect URL.",
+  "example_prompt": "Create a LengoPay payment request for a given amount.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/create_payment/schema.json
+++ b/specs/payment/lengopay/create_payment/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/lengopay/create_payment/schema.json
+++ b/specs/payment/lengopay/create_payment/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "lengopay",
-  "provider_name": "LengoPay",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "create_payment",
   "capability_type": "synchronous",
   "status": "verified",
-  "country_code": [
-    "GN"
-  ],
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/payments"
   },
+  "example_prompt": "Create a LengoPay payment request for a given amount and retrieve the payment reference for tracking.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/create_payment/schema.json
+++ b/specs/payment/lengopay/create_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/payments"
   },
-  "example_prompt": "Create a LengoPay payment request for a given amount.",
+  "example_prompt": "Add a LengoPay payment request to my checkout.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/get_balance/schema.json
+++ b/specs/payment/lengopay/get_balance/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "lengopay",
-  "provider_name": "LengoPay",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "get_balance",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "GN"
-  ],
+  "status": "ready",
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "GET",
     "url": "https://portal.lengopay.com/api/getbalance/{websiteId}"
   },
+  "example_prompt": "Retrieve the current LengoPay account balance before initiating a payout to ensure sufficient funds.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/get_balance/schema.json
+++ b/specs/payment/lengopay/get_balance/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://portal.lengopay.com/api/getbalance/{websiteId}"
   },
-  "example_prompt": "Write a Node.js function that retrieves the current LengoPay account balance. Use this before initiating payouts to verify sufficient funds.",
+  "example_prompt": "Check my LengoPay account balance.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/get_balance/schema.json
+++ b/specs/payment/lengopay/get_balance/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/lengopay/get_balance/schema.json
+++ b/specs/payment/lengopay/get_balance/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://portal.lengopay.com/api/getbalance/{websiteId}"
   },
-  "example_prompt": "Retrieve the current LengoPay account balance before initiating a payout to ensure sufficient funds.",
+  "example_prompt": "Write a Node.js function that retrieves the current LengoPay account balance. Use this before initiating payouts to verify sufficient funds.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/list_cashin_transactions/schema.json
+++ b/specs/payment/lengopay/list_cashin_transactions/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/lengopay/list_cashin_transactions/schema.json
+++ b/specs/payment/lengopay/list_cashin_transactions/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/cashin/all-transactions"
   },
-  "example_prompt": "List today's incoming LengoPay payments for reconciliation.",
+  "example_prompt": "List today's LengoPay incoming payments for reconciliation.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/list_cashin_transactions/schema.json
+++ b/specs/payment/lengopay/list_cashin_transactions/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "lengopay",
-  "provider_name": "LengoPay",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "list_cashin_transactions",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "GN"
-  ],
+  "status": "ready",
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/cashin/all-transactions"
   },
+  "example_prompt": "List LengoPay cashin transactions filtered by date range to reconcile incoming payments.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/list_cashin_transactions/schema.json
+++ b/specs/payment/lengopay/list_cashin_transactions/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/cashin/all-transactions"
   },
-  "example_prompt": "Write a Node.js function that fetches LengoPay cashin transactions for a given date range. Use this to reconcile incoming payments at end of day.",
+  "example_prompt": "List today's incoming LengoPay payments for reconciliation.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/list_cashin_transactions/schema.json
+++ b/specs/payment/lengopay/list_cashin_transactions/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/cashin/all-transactions"
   },
-  "example_prompt": "List LengoPay cashin transactions filtered by date range to reconcile incoming payments.",
+  "example_prompt": "Write a Node.js function that fetches LengoPay cashin transactions for a given date range. Use this to reconcile incoming payments at end of day.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/list_transactions/schema.json
+++ b/specs/payment/lengopay/list_transactions/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/lengopay/list_transactions/schema.json
+++ b/specs/payment/lengopay/list_transactions/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "lengopay",
-  "provider_name": "LengoPay",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "list_transactions",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "GN"
-  ],
+  "status": "ready",
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/transactions"
   },
+  "example_prompt": "Retrieve a paginated list of all LengoPay transactions for the account.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/list_transactions/schema.json
+++ b/specs/payment/lengopay/list_transactions/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/transactions"
   },
-  "example_prompt": "Retrieve a paginated list of all LengoPay transactions for the account.",
+  "example_prompt": "Write a Node.js function that retrieves all LengoPay account transactions with pagination. It accepts page and limit parameters and returns the transaction list.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/list_transactions/schema.json
+++ b/specs/payment/lengopay/list_transactions/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/transactions"
   },
-  "example_prompt": "Write a Node.js function that retrieves all LengoPay account transactions with pagination. It accepts page and limit parameters and returns the transaction list.",
+  "example_prompt": "Get all my LengoPay transactions.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/provider.json
+++ b/specs/payment/lengopay/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["GN"],
   "description": "LengoPay is a Guinean mobile money platform supporting multi-operator cashin and cashout via a REST API.",
-  "example_prompt": "I need to collect mobile money payments from my customers using LengoPay."
+  "example_prompt": "Add LengoPay mobile money payments to my app."
 }

--- a/specs/payment/lengopay/provider.json
+++ b/specs/payment/lengopay/provider.json
@@ -1,0 +1,8 @@
+{
+  "slug": "lengopay",
+  "name": "LengoPay",
+  "category": "payment",
+  "country_code": ["GN"],
+  "description": "LengoPay is a Guinean mobile money platform supporting multi-operator cashin and cashout via a REST API.",
+  "example_prompt": "Integrate LengoPay to initiate a mobile money cashin request, poll for the transaction status, and confirm completion before fulfilling the order."
+}

--- a/specs/payment/lengopay/provider.json
+++ b/specs/payment/lengopay/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["GN"],
   "description": "LengoPay is a Guinean mobile money platform supporting multi-operator cashin and cashout via a REST API.",
-  "example_prompt": "Add LengoPay mobile money collection to my app. Write a flow that initiates a cashin request for a given amount, polls for the transaction status, and triggers order fulfillment once the payment is confirmed."
+  "example_prompt": "I need to collect mobile money payments from my customers using LengoPay."
 }

--- a/specs/payment/lengopay/provider.json
+++ b/specs/payment/lengopay/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["GN"],
   "description": "LengoPay is a Guinean mobile money platform supporting multi-operator cashin and cashout via a REST API.",
-  "example_prompt": "Integrate LengoPay to initiate a mobile money cashin request, poll for the transaction status, and confirm completion before fulfilling the order."
+  "example_prompt": "Add LengoPay mobile money collection to my app. Write a flow that initiates a cashin request for a given amount, polls for the transaction status, and triggers order fulfillment once the payment is confirmed."
 }

--- a/specs/payment/lengopay/provider.json
+++ b/specs/payment/lengopay/provider.json
@@ -2,7 +2,13 @@
   "slug": "lengopay",
   "name": "LengoPay",
   "category": "payment",
-  "country_code": ["GN"],
+  "country_code": [
+    "GN"
+  ],
+  "website": "https://lengopay.com",
+  "docs_url": "",
+  "docs_public": false,
+  "sandbox": false,
   "description": "LengoPay is a Guinean mobile money platform supporting multi-operator cashin and cashout via a REST API.",
   "example_prompt": "Add LengoPay mobile money payments to my app."
 }

--- a/specs/payment/lengopay/verify_payment/schema.json
+++ b/specs/payment/lengopay/verify_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/transaction/status"
   },
-  "example_prompt": "Write a Node.js function that verifies a LengoPay payment status using its transaction reference. Call this server-side before fulfilling an order.",
+  "example_prompt": "Verify server-side that a LengoPay payment went through before I fulfill the order.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/verify_payment/schema.json
+++ b/specs/payment/lengopay/verify_payment/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/lengopay/verify_payment/schema.json
+++ b/specs/payment/lengopay/verify_payment/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "lengopay",
-  "provider_name": "LengoPay",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "verify_payment",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "GN"
-  ],
+  "status": "ready",
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/transaction/status"
   },
+  "example_prompt": "Verify the status of a LengoPay payment using its transaction reference before fulfilling an order.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/verify_payment/schema.json
+++ b/specs/payment/lengopay/verify_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/transaction/status"
   },
-  "example_prompt": "Verify server-side that a LengoPay payment went through before I fulfill the order.",
+  "example_prompt": "Add server-side LengoPay payment verification to my order fulfillment flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/verify_payment/schema.json
+++ b/specs/payment/lengopay/verify_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://portal.lengopay.com/api/v1/transaction/status"
   },
-  "example_prompt": "Verify the status of a LengoPay payment using its transaction reference before fulfilling an order.",
+  "example_prompt": "Write a Node.js function that verifies a LengoPay payment status using its transaction reference. Call this server-side before fulfilling an order.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/lengopay/webhook_payment_completed/schema.json
+++ b/specs/payment/lengopay/webhook_payment_completed/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "lengopay",
-  "provider_name": "LengoPay",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "webhook_payment_completed",
   "capability_type": "webhook",
   "status": "verified",
-  "country_code": [
-    "GN"
-  ],
   "currency": [
     "GNF"
   ],
@@ -23,6 +17,7 @@
     "method": "POST",
     "url": "{your_callback_url}"
   },
+  "example_prompt": "Handle an incoming LengoPay webhook to confirm payment completion and trigger order fulfillment.",
   "input_schema": {
     "type": "object",
     "description": "Payload que LengoPay POSTe à votre callback_url lorsqu'un paiement est traité.",

--- a/specs/payment/lengopay/webhook_payment_completed/schema.json
+++ b/specs/payment/lengopay/webhook_payment_completed/schema.json
@@ -17,7 +17,7 @@
     "method": "POST",
     "url": "{your_callback_url}"
   },
-  "example_prompt": "Handle the LengoPay webhook that fires when a payment is confirmed.",
+  "example_prompt": "Add a LengoPay webhook handler to automatically confirm orders when payment completes.",
   "input_schema": {
     "type": "object",
     "description": "Payload que LengoPay POSTe à votre callback_url lorsqu'un paiement est traité.",

--- a/specs/payment/lengopay/webhook_payment_completed/schema.json
+++ b/specs/payment/lengopay/webhook_payment_completed/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "none"
   },

--- a/specs/payment/lengopay/webhook_payment_completed/schema.json
+++ b/specs/payment/lengopay/webhook_payment_completed/schema.json
@@ -17,7 +17,7 @@
     "method": "POST",
     "url": "{your_callback_url}"
   },
-  "example_prompt": "Handle an incoming LengoPay webhook to confirm payment completion and trigger order fulfillment.",
+  "example_prompt": "Write an Express route POST /webhooks/lengopay that receives a LengoPay payment completion event and triggers order fulfillment after validating the payload.",
   "input_schema": {
     "type": "object",
     "description": "Payload que LengoPay POSTe à votre callback_url lorsqu'un paiement est traité.",

--- a/specs/payment/lengopay/webhook_payment_completed/schema.json
+++ b/specs/payment/lengopay/webhook_payment_completed/schema.json
@@ -17,7 +17,7 @@
     "method": "POST",
     "url": "{your_callback_url}"
   },
-  "example_prompt": "Write an Express route POST /webhooks/lengopay that receives a LengoPay payment completion event and triggers order fulfillment after validating the payload.",
+  "example_prompt": "Handle the LengoPay webhook that fires when a payment is confirmed.",
   "input_schema": {
     "type": "object",
     "description": "Payload que LengoPay POSTe à votre callback_url lorsqu'un paiement est traité.",

--- a/specs/payment/paycard/create_payment/schema.json
+++ b/specs/payment/paycard/create_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://mapaycard.com/epay/create/"
   },
-  "example_prompt": "I need to accept a mobile money payment in Guinea with Paycard.",
+  "example_prompt": "Add Paycard mobile money payment to my checkout.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/paycard/create_payment/schema.json
+++ b/specs/payment/paycard/create_payment/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "api_key",
     "location": "body",

--- a/specs/payment/paycard/create_payment/schema.json
+++ b/specs/payment/paycard/create_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://mapaycard.com/epay/create/"
   },
-  "example_prompt": "Initiate a Paycard mobile money payment for a given amount in GNF, extract the operation_reference from the response, and store it immediately before redirecting the user.",
+  "example_prompt": "Write a Node.js function that initiates a Paycard mobile money payment. It receives an amount in GNF and a callback URL, calls the Paycard create_payment endpoint, and returns the operation_reference to use for server-side verification.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/paycard/create_payment/schema.json
+++ b/specs/payment/paycard/create_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://mapaycard.com/epay/create/"
   },
-  "example_prompt": "Write a Node.js function that initiates a Paycard mobile money payment. It receives an amount in GNF and a callback URL, calls the Paycard create_payment endpoint, and returns the operation_reference to use for server-side verification.",
+  "example_prompt": "I need to accept a mobile money payment in Guinea with Paycard.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/paycard/create_payment/schema.json
+++ b/specs/payment/paycard/create_payment/schema.json
@@ -1,15 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "paycard",
-  "provider_name": "Paycard",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "create_payment",
   "capability_type": "synchronous",
   "status": "verified",
-  "country_code": [
-    "GN"
-  ],
   "currency": [
     "GNF"
   ],
@@ -27,6 +21,7 @@
     "method": "POST",
     "url": "https://mapaycard.com/epay/create/"
   },
+  "example_prompt": "Initiate a Paycard mobile money payment for a given amount in GNF, extract the operation_reference from the response, and store it immediately before redirecting the user.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/paycard/provider.json
+++ b/specs/payment/paycard/provider.json
@@ -2,7 +2,13 @@
   "slug": "paycard",
   "name": "Paycard",
   "category": "payment",
-  "country_code": ["GN"],
+  "country_code": [
+    "GN"
+  ],
+  "website": "https://mapaycard.com",
+  "docs_url": "",
+  "docs_public": false,
+  "sandbox": false,
   "description": "Paycard is a Guinean mobile money payment gateway that lets you accept payments via MTN, Orange, and Cellcom mobile wallets. No sandbox — all requests hit production.",
   "example_prompt": "Add Paycard mobile money payments to my app."
 }

--- a/specs/payment/paycard/provider.json
+++ b/specs/payment/paycard/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["GN"],
   "description": "Paycard is a Guinean mobile money payment gateway that lets you accept payments via MTN, Orange, and Cellcom mobile wallets. No sandbox — all requests hit production.",
-  "example_prompt": "Integrate Paycard to accept mobile money payments in Guinea. Create a payment, extract the operation_reference, and verify the transaction server-side before fulfilling the order."
+  "example_prompt": "I need to accept mobile money payments in Guinea with Paycard. Write a complete checkout flow: create a payment, redirect the user to the payment page, verify the transaction server-side using the operation_reference, and handle the webhook confirmation before fulfilling the order."
 }

--- a/specs/payment/paycard/provider.json
+++ b/specs/payment/paycard/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["GN"],
   "description": "Paycard is a Guinean mobile money payment gateway that lets you accept payments via MTN, Orange, and Cellcom mobile wallets. No sandbox — all requests hit production.",
-  "example_prompt": "I need to accept mobile money payments in Guinea with Paycard."
+  "example_prompt": "Add Paycard mobile money payments to my app."
 }

--- a/specs/payment/paycard/provider.json
+++ b/specs/payment/paycard/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["GN"],
   "description": "Paycard is a Guinean mobile money payment gateway that lets you accept payments via MTN, Orange, and Cellcom mobile wallets. No sandbox — all requests hit production.",
-  "example_prompt": "I need to accept mobile money payments in Guinea with Paycard. Write a complete checkout flow: create a payment, redirect the user to the payment page, verify the transaction server-side using the operation_reference, and handle the webhook confirmation before fulfilling the order."
+  "example_prompt": "I need to accept mobile money payments in Guinea with Paycard."
 }

--- a/specs/payment/paycard/provider.json
+++ b/specs/payment/paycard/provider.json
@@ -1,0 +1,8 @@
+{
+  "slug": "paycard",
+  "name": "Paycard",
+  "category": "payment",
+  "country_code": ["GN"],
+  "description": "Paycard is a Guinean mobile money payment gateway that lets you accept payments via MTN, Orange, and Cellcom mobile wallets. No sandbox — all requests hit production.",
+  "example_prompt": "Integrate Paycard to accept mobile money payments in Guinea. Create a payment, extract the operation_reference, and verify the transaction server-side before fulfilling the order."
+}

--- a/specs/payment/paycard/verify_payment/schema.json
+++ b/specs/payment/paycard/verify_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://mapaycard.com/epay/{c}/{ref}/status"
   },
-  "example_prompt": "Verify a Paycard payment status server-side using the operation_reference before fulfilling an order — never rely solely on the callback URL.",
+  "example_prompt": "Write a Node.js function that verifies a Paycard payment server-side using an operation_reference. Return the payment status and call this before fulfilling any order — never rely on the callback URL alone.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/paycard/verify_payment/schema.json
+++ b/specs/payment/paycard/verify_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://mapaycard.com/epay/{c}/{ref}/status"
   },
-  "example_prompt": "Write a Node.js function that verifies a Paycard payment server-side using an operation_reference. Return the payment status and call this before fulfilling any order — never rely on the callback URL alone.",
+  "example_prompt": "Check server-side if a Paycard payment was actually completed before I ship the order.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/paycard/verify_payment/schema.json
+++ b/specs/payment/paycard/verify_payment/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://mapaycard.com/epay/{c}/{ref}/status"
   },
-  "example_prompt": "Check server-side if a Paycard payment was actually completed before I ship the order.",
+  "example_prompt": "Add server-side Paycard payment verification to my order fulfillment flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/paycard/verify_payment/schema.json
+++ b/specs/payment/paycard/verify_payment/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "paycard",
-  "provider_name": "Paycard",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "verify_payment",
   "capability_type": "synchronous",
   "status": "verified",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "",
   "docs_public": false,
@@ -23,9 +21,12 @@
     "method": "GET",
     "url": "https://mapaycard.com/epay/{c}/{ref}/status"
   },
+  "example_prompt": "Verify a Paycard payment status server-side using the operation_reference before fulfilling an order — never rely solely on the callback URL.",
   "input_schema": {
     "type": "object",
-    "required": ["ref"],
+    "required": [
+      "ref"
+    ],
     "properties": {
       "ref": {
         "type": "string",
@@ -65,27 +66,48 @@
         "description": "Payment status. Known values: 'new' (pending, do not fulfill), 'success' (paid). Check case-insensitively. Paycard does not document all possible values."
       },
       "status_description": {
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "ecommerce_description": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "Order description echoed back."
       },
       "payment_method": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "Method used, e.g. ORANGE_MONEY, MOMO, CREDIT_CARD, PAYCARD. Null until payment completes."
       },
       "payment_method_reference": {
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "payment_reference": {
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "payment_description": {
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "transaction_date": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "Date and time of the transaction. Null until payment completes."
       }
     }

--- a/specs/payment/paycard/verify_payment/schema.json
+++ b/specs/payment/paycard/verify_payment/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "api_key",
     "location": "path",

--- a/specs/payment/paycard/webhook_payment_completed/schema.json
+++ b/specs/payment/paycard/webhook_payment_completed/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "paycard",
-  "provider_name": "Paycard",
   "provider_api_version": "2024-01-01",
-  "category": "payment",
   "capability": "webhook_payment_completed",
   "capability_type": "webhook",
   "status": "verified",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "",
   "docs_public": false,
@@ -19,6 +17,7 @@
     "method": "POST",
     "url": "{your_callback_url}"
   },
+  "example_prompt": "Handle an incoming Paycard webhook to confirm a mobile money payment completed, validate the payload, and credit the user's account.",
   "input_schema": {
     "type": "object",
     "description": "Payload Paycard POSTs to your paycard-callback-url when a payment completes.",

--- a/specs/payment/paycard/webhook_payment_completed/schema.json
+++ b/specs/payment/paycard/webhook_payment_completed/schema.json
@@ -17,7 +17,7 @@
     "method": "POST",
     "url": "{your_callback_url}"
   },
-  "example_prompt": "Handle the Paycard webhook that fires when a payment is done.",
+  "example_prompt": "Add a Paycard webhook handler to automatically confirm orders when payment completes.",
   "input_schema": {
     "type": "object",
     "description": "Payload Paycard POSTs to your paycard-callback-url when a payment completes.",

--- a/specs/payment/paycard/webhook_payment_completed/schema.json
+++ b/specs/payment/paycard/webhook_payment_completed/schema.json
@@ -17,7 +17,7 @@
     "method": "POST",
     "url": "{your_callback_url}"
   },
-  "example_prompt": "Write an Express route POST /webhooks/paycard that receives a Paycard payment completion event, validates the payload, and marks the corresponding order as paid.",
+  "example_prompt": "Handle the Paycard webhook that fires when a payment is done.",
   "input_schema": {
     "type": "object",
     "description": "Payload Paycard POSTs to your paycard-callback-url when a payment completes.",

--- a/specs/payment/paycard/webhook_payment_completed/schema.json
+++ b/specs/payment/paycard/webhook_payment_completed/schema.json
@@ -17,7 +17,7 @@
     "method": "POST",
     "url": "{your_callback_url}"
   },
-  "example_prompt": "Handle an incoming Paycard webhook to confirm a mobile money payment completed, validate the payload, and credit the user's account.",
+  "example_prompt": "Write an Express route POST /webhooks/paycard that receives a Paycard payment completion event, validates the payload, and marks the corresponding order as paid.",
   "input_schema": {
     "type": "object",
     "description": "Payload Paycard POSTs to your paycard-callback-url when a payment completes.",

--- a/specs/payment/paycard/webhook_payment_completed/schema.json
+++ b/specs/payment/paycard/webhook_payment_completed/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "",
-  "docs_public": false,
   "auth": {
     "type": "none"
   },

--- a/specs/payment/wave/create_checkout_session/schema.json
+++ b/specs/payment/wave/create_checkout_session/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions"
   },
-  "example_prompt": "Create a Wave checkout session for a payment, redirect the user to the wave_launch_url, and listen for the webhook to confirm completion.",
+  "example_prompt": "Write a Node.js function that creates a Wave checkout session. It receives an amount, currency, and success URL, calls Wave's API, and returns the wave_launch_url to redirect the user to.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/create_checkout_session/schema.json
+++ b/specs/payment/wave/create_checkout_session/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions"
   },
-  "example_prompt": "Create a Wave payment page for my customer and get the URL to redirect them to.",
+  "example_prompt": "Add Wave checkout to my e-commerce payment flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/create_checkout_session/schema.json
+++ b/specs/payment/wave/create_checkout_session/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/checkout",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/create_checkout_session/schema.json
+++ b/specs/payment/wave/create_checkout_session/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions"
   },
-  "example_prompt": "Write a Node.js function that creates a Wave checkout session. It receives an amount, currency, and success URL, calls Wave's API, and returns the wave_launch_url to redirect the user to.",
+  "example_prompt": "Create a Wave payment page for my customer and get the URL to redirect them to.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/create_checkout_session/schema.json
+++ b/specs/payment/wave/create_checkout_session/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "create_checkout_session",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions"
   },
+  "example_prompt": "Create a Wave checkout session for a payment, redirect the user to the wave_launch_url, and listen for the webhook to confirm completion.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/create_payout_batch/schema.json
+++ b/specs/payment/wave/create_payout_batch/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/payout-batch"
   },
-  "example_prompt": "Send payouts to multiple recipients at once via Wave.",
+  "example_prompt": "Add batch Wave payouts to multiple recipients to my payout workflow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/create_payout_batch/schema.json
+++ b/specs/payment/wave/create_payout_batch/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/payout",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/create_payout_batch/schema.json
+++ b/specs/payment/wave/create_payout_batch/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/payout-batch"
   },
-  "example_prompt": "Write a Node.js function that sends a batch payout to multiple recipients via Wave. It receives an array of {phone, amount} objects and calls Wave's create_payout_batch endpoint.",
+  "example_prompt": "Send payouts to multiple recipients at once via Wave.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/create_payout_batch/schema.json
+++ b/specs/payment/wave/create_payout_batch/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/payout-batch"
   },
-  "example_prompt": "Create a batch Wave payout to multiple mobile money recipients in a single API call.",
+  "example_prompt": "Write a Node.js function that sends a batch payout to multiple recipients via Wave. It receives an array of {phone, amount} objects and calls Wave's create_payout_batch endpoint.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/create_payout_batch/schema.json
+++ b/specs/payment/wave/create_payout_batch/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "create_payout_batch",
   "capability_type": "asynchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/payout-batch"
   },
+  "example_prompt": "Create a batch Wave payout to multiple mobile money recipients in a single API call.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/expire_checkout/schema.json
+++ b/specs/payment/wave/expire_checkout/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "expire_checkout",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}/expire"
   },
+  "example_prompt": "Expire an active Wave checkout session before its natural 30-minute timeout to cancel a pending payment.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/expire_checkout/schema.json
+++ b/specs/payment/wave/expire_checkout/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}/expire"
   },
-  "example_prompt": "Expire an active Wave checkout session before its natural 30-minute timeout to cancel a pending payment.",
+  "example_prompt": "Write a Node.js function that expires an active Wave checkout session by its session ID. Use this when a user abandons the payment flow and you need to cancel the pending session.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/expire_checkout/schema.json
+++ b/specs/payment/wave/expire_checkout/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/checkout",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/expire_checkout/schema.json
+++ b/specs/payment/wave/expire_checkout/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}/expire"
   },
-  "example_prompt": "Cancel a Wave payment session my customer abandoned.",
+  "example_prompt": "Add cancellation of abandoned Wave checkout sessions to my payment flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/expire_checkout/schema.json
+++ b/specs/payment/wave/expire_checkout/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}/expire"
   },
-  "example_prompt": "Write a Node.js function that expires an active Wave checkout session by its session ID. Use this when a user abandons the payment flow and you need to cancel the pending session.",
+  "example_prompt": "Cancel a Wave payment session my customer abandoned.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/get_balance/schema.json
+++ b/specs/payment/wave/get_balance/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "get_balance",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/balance"
   },
+  "example_prompt": "Retrieve the current balance of the Wave wallet associated with the API key.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/payment/wave/get_balance/schema.json
+++ b/specs/payment/wave/get_balance/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/balance"
   },
-  "example_prompt": "Write a Node.js function that retrieves the Wave wallet balance for the authenticated API key. Use this to verify available funds before initiating payouts.",
+  "example_prompt": "Check my Wave wallet balance.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/payment/wave/get_balance/schema.json
+++ b/specs/payment/wave/get_balance/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/balance-api",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/get_balance/schema.json
+++ b/specs/payment/wave/get_balance/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/balance"
   },
-  "example_prompt": "Retrieve the current balance of the Wave wallet associated with the API key.",
+  "example_prompt": "Write a Node.js function that retrieves the Wave wallet balance for the authenticated API key. Use this to verify available funds before initiating payouts.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/payment/wave/get_payout/schema.json
+++ b/specs/payment/wave/get_payout/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/payout/{id}"
   },
-  "example_prompt": "Write a Node.js function that checks the status of a Wave payout by its payout ID. Use this to confirm whether a payout has settled.",
+  "example_prompt": "Check the status of a Wave payout I sent.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/get_payout/schema.json
+++ b/specs/payment/wave/get_payout/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/payout",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/get_payout/schema.json
+++ b/specs/payment/wave/get_payout/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/payout/{id}"
   },
-  "example_prompt": "Get the current status and details of a Wave payout using its payout ID.",
+  "example_prompt": "Write a Node.js function that checks the status of a Wave payout by its payout ID. Use this to confirm whether a payout has settled.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/get_payout/schema.json
+++ b/specs/payment/wave/get_payout/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "get_payout",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/payout/{id}"
   },
+  "example_prompt": "Get the current status and details of a Wave payout using its payout ID.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/get_transactions/schema.json
+++ b/specs/payment/wave/get_transactions/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "get_transactions",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/transactions"
   },
+  "example_prompt": "Retrieve a paginated list of recent Wave wallet transactions.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/payment/wave/get_transactions/schema.json
+++ b/specs/payment/wave/get_transactions/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/transactions"
   },
-  "example_prompt": "Write a Node.js function that retrieves recent Wave wallet transactions. It accepts a pagination cursor and returns a list of transactions with the next cursor.",
+  "example_prompt": "Get my recent Wave wallet transactions.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/payment/wave/get_transactions/schema.json
+++ b/specs/payment/wave/get_transactions/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/balance-api",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/get_transactions/schema.json
+++ b/specs/payment/wave/get_transactions/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/transactions"
   },
-  "example_prompt": "Retrieve a paginated list of recent Wave wallet transactions.",
+  "example_prompt": "Write a Node.js function that retrieves recent Wave wallet transactions. It accepts a pagination cursor and returns a list of transactions with the next cursor.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/payment/wave/provider.json
+++ b/specs/payment/wave/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["SN", "CI", "ML", "GN", "UG", "BF", "GM", "NE", "CM", "SL", "CD"],
   "description": "Wave is a mobile money operator active in 11 African countries offering checkout sessions for e-commerce payments and batch payouts via a REST API.",
-  "example_prompt": "Use Wave to create a checkout session for an e-commerce payment, redirect the user to the Wave payment page, and confirm the transaction via webhook before fulfilling the order."
+  "example_prompt": "Integrate Wave payments into my e-commerce app. Write a flow that creates a checkout session for a given amount, redirects the user to the Wave payment page, and handles the webhook to verify payment completion before fulfilling the order."
 }

--- a/specs/payment/wave/provider.json
+++ b/specs/payment/wave/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["SN", "CI", "ML", "GN", "UG", "BF", "GM", "NE", "CM", "SL", "CD"],
   "description": "Wave is a mobile money operator active in 11 African countries offering checkout sessions for e-commerce payments and batch payouts via a REST API.",
-  "example_prompt": "I want to add Wave checkout to my e-commerce app."
+  "example_prompt": "Add Wave checkout to my e-commerce app."
 }

--- a/specs/payment/wave/provider.json
+++ b/specs/payment/wave/provider.json
@@ -4,5 +4,5 @@
   "category": "payment",
   "country_code": ["SN", "CI", "ML", "GN", "UG", "BF", "GM", "NE", "CM", "SL", "CD"],
   "description": "Wave is a mobile money operator active in 11 African countries offering checkout sessions for e-commerce payments and batch payouts via a REST API.",
-  "example_prompt": "Integrate Wave payments into my e-commerce app. Write a flow that creates a checkout session for a given amount, redirects the user to the Wave payment page, and handles the webhook to verify payment completion before fulfilling the order."
+  "example_prompt": "I want to add Wave checkout to my e-commerce app."
 }

--- a/specs/payment/wave/provider.json
+++ b/specs/payment/wave/provider.json
@@ -2,7 +2,23 @@
   "slug": "wave",
   "name": "Wave",
   "category": "payment",
-  "country_code": ["SN", "CI", "ML", "GN", "UG", "BF", "GM", "NE", "CM", "SL", "CD"],
+  "country_code": [
+    "SN",
+    "CI",
+    "ML",
+    "GN",
+    "UG",
+    "BF",
+    "GM",
+    "NE",
+    "CM",
+    "SL",
+    "CD"
+  ],
+  "website": "https://www.wave.com",
+  "docs_url": "https://docs.wave.com",
+  "docs_public": true,
+  "sandbox": false,
   "description": "Wave is a mobile money operator active in 11 African countries offering checkout sessions for e-commerce payments and batch payouts via a REST API.",
   "example_prompt": "Add Wave checkout to my e-commerce app."
 }

--- a/specs/payment/wave/provider.json
+++ b/specs/payment/wave/provider.json
@@ -1,0 +1,8 @@
+{
+  "slug": "wave",
+  "name": "Wave",
+  "category": "payment",
+  "country_code": ["SN", "CI", "ML", "GN", "UG", "BF", "GM", "NE", "CM", "SL", "CD"],
+  "description": "Wave is a mobile money operator active in 11 African countries offering checkout sessions for e-commerce payments and batch payouts via a REST API.",
+  "example_prompt": "Use Wave to create a checkout session for an e-commerce payment, redirect the user to the Wave payment page, and confirm the transaction via webhook before fulfilling the order."
+}

--- a/specs/payment/wave/refund_checkout/schema.json
+++ b/specs/payment/wave/refund_checkout/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}/refund"
   },
-  "example_prompt": "Refund a Wave payment to my customer.",
+  "example_prompt": "Add Wave payment refunds to my order management flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/refund_checkout/schema.json
+++ b/specs/payment/wave/refund_checkout/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/checkout",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/refund_checkout/schema.json
+++ b/specs/payment/wave/refund_checkout/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}/refund"
   },
-  "example_prompt": "Write a Node.js function that refunds a completed Wave checkout session. It receives the session ID and calls Wave's refund endpoint.",
+  "example_prompt": "Refund a Wave payment to my customer.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/refund_checkout/schema.json
+++ b/specs/payment/wave/refund_checkout/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}/refund"
   },
-  "example_prompt": "Initiate a refund for a completed Wave checkout session and confirm the refund status.",
+  "example_prompt": "Write a Node.js function that refunds a completed Wave checkout session. It receives the session ID and calls Wave's refund endpoint.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/refund_checkout/schema.json
+++ b/specs/payment/wave/refund_checkout/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "refund_checkout",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}/refund"
   },
+  "example_prompt": "Initiate a refund for a completed Wave checkout session and confirm the refund status.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/search_checkouts/schema.json
+++ b/specs/payment/wave/search_checkouts/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/checkout",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/search_checkouts/schema.json
+++ b/specs/payment/wave/search_checkouts/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/checkout/sessions/search"
   },
-  "example_prompt": "List Wave payments from the last 7 days for reconciliation.",
+  "example_prompt": "List Wave payments from the past week for daily reconciliation.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/search_checkouts/schema.json
+++ b/specs/payment/wave/search_checkouts/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "search_checkouts",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/checkout/sessions/search"
   },
+  "example_prompt": "Search Wave checkout sessions by date range or status to reconcile payments.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/search_checkouts/schema.json
+++ b/specs/payment/wave/search_checkouts/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/checkout/sessions/search"
   },
-  "example_prompt": "Search Wave checkout sessions by date range or status to reconcile payments.",
+  "example_prompt": "Write a Node.js function that searches Wave checkout sessions by date range and status. Use this to reconcile daily payments.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/search_checkouts/schema.json
+++ b/specs/payment/wave/search_checkouts/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/checkout/sessions/search"
   },
-  "example_prompt": "Write a Node.js function that searches Wave checkout sessions by date range and status. Use this to reconcile daily payments.",
+  "example_prompt": "List Wave payments from the last 7 days for reconciliation.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/send_payout/schema.json
+++ b/specs/payment/wave/send_payout/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "send_payout",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/payout"
   },
+  "example_prompt": "Send a single Wave payout to a mobile money recipient using their phone number.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/send_payout/schema.json
+++ b/specs/payment/wave/send_payout/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/payout",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/send_payout/schema.json
+++ b/specs/payment/wave/send_payout/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/payout"
   },
-  "example_prompt": "Write a Node.js function that sends a single Wave payout to a mobile money recipient. It receives a phone number and amount and returns the payout ID for tracking.",
+  "example_prompt": "Send money to a recipient's Wave mobile wallet.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/send_payout/schema.json
+++ b/specs/payment/wave/send_payout/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/payout"
   },
-  "example_prompt": "Send a single Wave payout to a mobile money recipient using their phone number.",
+  "example_prompt": "Write a Node.js function that sends a single Wave payout to a mobile money recipient. It receives a phone number and amount and returns the payout ID for tracking.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/send_payout/schema.json
+++ b/specs/payment/wave/send_payout/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/payout"
   },
-  "example_prompt": "Send money to a recipient's Wave mobile wallet.",
+  "example_prompt": "Add Wave payouts to my disbursement flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/verify_payment/schema.json
+++ b/specs/payment/wave/verify_payment/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/checkout",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/verify_payment/schema.json
+++ b/specs/payment/wave/verify_payment/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}"
   },
-  "example_prompt": "Write a Node.js function that verifies a Wave checkout session status by session ID. Call this server-side before fulfilling an order.",
+  "example_prompt": "Verify server-side that a Wave checkout was actually paid before I ship the order.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/verify_payment/schema.json
+++ b/specs/payment/wave/verify_payment/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}"
   },
-  "example_prompt": "Verify server-side that a Wave checkout was actually paid before I ship the order.",
+  "example_prompt": "Add server-side Wave payment verification to my order fulfillment flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/verify_payment/schema.json
+++ b/specs/payment/wave/verify_payment/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "verify_payment",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}"
   },
+  "example_prompt": "Verify the status of a Wave checkout session using its session ID to confirm payment before fulfilling an order.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/verify_payment/schema.json
+++ b/specs/payment/wave/verify_payment/schema.json
@@ -27,7 +27,7 @@
     "method": "GET",
     "url": "https://api.wave.com/v1/checkout/sessions/{id}"
   },
-  "example_prompt": "Verify the status of a Wave checkout session using its session ID to confirm payment before fulfilling an order.",
+  "example_prompt": "Write a Node.js function that verifies a Wave checkout session status by session ID. Call this server-side before fulfilling an order.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/verify_recipient/schema.json
+++ b/specs/payment/wave/verify_recipient/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/verify_recipient"
   },
-  "example_prompt": "Write a Node.js function that checks whether a phone number is a valid Wave recipient before sending a payout. Use this to avoid failed payout attempts.",
+  "example_prompt": "Check that a phone number can receive a Wave payout before I send it.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/verify_recipient/schema.json
+++ b/specs/payment/wave/verify_recipient/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/verify_recipient"
   },
-  "example_prompt": "Check that a phone number can receive a Wave payout before I send it.",
+  "example_prompt": "Add a Wave recipient check before sending a payout.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/verify_recipient/schema.json
+++ b/specs/payment/wave/verify_recipient/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/payout",
-  "docs_public": true,
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/payment/wave/verify_recipient/schema.json
+++ b/specs/payment/wave/verify_recipient/schema.json
@@ -1,25 +1,9 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "verify_recipient",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": [
-    "SN",
-    "CI",
-    "ML",
-    "GN",
-    "UG",
-    "BF",
-    "GM",
-    "NE",
-    "CM",
-    "SL",
-    "CD"
-  ],
+  "status": "ready",
   "currency": [
     "XOF",
     "GNF",
@@ -43,6 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/verify_recipient"
   },
+  "example_prompt": "Verify that a phone number is a valid Wave recipient before sending a payout.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/verify_recipient/schema.json
+++ b/specs/payment/wave/verify_recipient/schema.json
@@ -27,7 +27,7 @@
     "method": "POST",
     "url": "https://api.wave.com/v1/verify_recipient"
   },
-  "example_prompt": "Verify that a phone number is a valid Wave recipient before sending a payout.",
+  "example_prompt": "Write a Node.js function that checks whether a phone number is a valid Wave recipient before sending a payout. Use this to avoid failed payout attempts.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/payment/wave/webhook_payment_completed/schema.json
+++ b/specs/payment/wave/webhook_payment_completed/schema.json
@@ -1,14 +1,18 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "wave",
-  "provider_name": "Wave",
   "provider_api_version": "2024-03-29",
-  "category": "payment",
   "capability": "webhook_payment_completed",
   "capability_type": "webhook",
-  "status": "compliant",
-  "country_code": ["SN", "CI", "ML", "GN", "UG", "BF", "GM", "NE", "CM", "SL", "CD"],
-  "currency": ["XOF", "GNF", "UGX", "GMD", "XAF", "SLE", "CDF"],
+  "status": "ready",
+  "currency": [
+    "XOF",
+    "GNF",
+    "UGX",
+    "GMD",
+    "XAF",
+    "SLE",
+    "CDF"
+  ],
   "sandbox": false,
   "docs_url": "https://docs.wave.com/webhook",
   "docs_public": true,
@@ -19,6 +23,7 @@
     "method": "POST",
     "url": "{your_webhook_url}"
   },
+  "example_prompt": "Handle an incoming Wave webhook event to confirm a checkout payment completed and update the order status.",
   "input_schema": {
     "type": "object",
     "description": "Payload que Wave POSTe à votre endpoint lors d'un événement checkout.session.completed.",
@@ -29,7 +34,9 @@
       },
       "type": {
         "type": "string",
-        "enum": ["checkout.session.completed"],
+        "enum": [
+          "checkout.session.completed"
+        ],
         "description": "Type de l'événement."
       },
       "data": {
@@ -42,12 +49,16 @@
           },
           "checkout_status": {
             "type": "string",
-            "enum": ["complete"],
+            "enum": [
+              "complete"
+            ],
             "description": "Toujours 'complete' pour cet événement."
           },
           "payment_status": {
             "type": "string",
-            "enum": ["succeeded"],
+            "enum": [
+              "succeeded"
+            ],
             "description": "Toujours 'succeeded' pour cet événement."
           },
           "amount": {

--- a/specs/payment/wave/webhook_payment_completed/schema.json
+++ b/specs/payment/wave/webhook_payment_completed/schema.json
@@ -23,7 +23,7 @@
     "method": "POST",
     "url": "{your_webhook_url}"
   },
-  "example_prompt": "Handle an incoming Wave webhook event to confirm a checkout payment completed and update the order status.",
+  "example_prompt": "Write an Express route POST /webhooks/wave that receives a Wave payment completion event, verifies the session status server-side, and triggers order fulfillment.",
   "input_schema": {
     "type": "object",
     "description": "Payload que Wave POSTe à votre endpoint lors d'un événement checkout.session.completed.",

--- a/specs/payment/wave/webhook_payment_completed/schema.json
+++ b/specs/payment/wave/webhook_payment_completed/schema.json
@@ -23,7 +23,7 @@
     "method": "POST",
     "url": "{your_webhook_url}"
   },
-  "example_prompt": "Handle the Wave webhook that fires when a checkout is paid.",
+  "example_prompt": "Add a Wave webhook handler to automatically confirm orders when payment completes.",
   "input_schema": {
     "type": "object",
     "description": "Payload que Wave POSTe à votre endpoint lors d'un événement checkout.session.completed.",

--- a/specs/payment/wave/webhook_payment_completed/schema.json
+++ b/specs/payment/wave/webhook_payment_completed/schema.json
@@ -13,9 +13,6 @@
     "SLE",
     "CDF"
   ],
-  "sandbox": false,
-  "docs_url": "https://docs.wave.com/webhook",
-  "docs_public": true,
   "auth": {
     "type": "none"
   },

--- a/specs/payment/wave/webhook_payment_completed/schema.json
+++ b/specs/payment/wave/webhook_payment_completed/schema.json
@@ -23,7 +23,7 @@
     "method": "POST",
     "url": "{your_webhook_url}"
   },
-  "example_prompt": "Write an Express route POST /webhooks/wave that receives a Wave payment completion event, verifies the session status server-side, and triggers order fulfillment.",
+  "example_prompt": "Handle the Wave webhook that fires when a checkout is paid.",
   "input_schema": {
     "type": "object",
     "description": "Payload que Wave POSTe à votre endpoint lors d'un événement checkout.session.completed.",

--- a/specs/sms/nimbasms/create_contact/schema.json
+++ b/specs/sms/nimbasms/create_contact/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "create_contact",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -23,9 +21,12 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/contacts"
   },
+  "example_prompt": "Create a new contact in the NimbaSMS address book for use in future messaging campaigns.",
   "input_schema": {
     "type": "object",
-    "required": ["numero"],
+    "required": [
+      "numero"
+    ],
     "properties": {
       "numero": {
         "type": "string",
@@ -37,7 +38,9 @@
       },
       "groups": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Noms des groupes auxquels ajouter le contact (optionnel). Les groupes doivent exister dans votre compte."
       }
     }
@@ -55,7 +58,9 @@
       },
       "groups": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Groupes auxquels le contact a été ajouté."
       }
     }
@@ -69,12 +74,16 @@
       },
       "numero": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Erreurs de validation sur le champ 'numero' (format invalide, doublon)."
       },
       "groups": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Erreurs de validation sur le champ 'groups' (groupe inexistant)."
       }
     }

--- a/specs/sms/nimbasms/create_contact/schema.json
+++ b/specs/sms/nimbasms/create_contact/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/contacts"
   },
-  "example_prompt": "Write a Node.js function that adds a contact to the NimbaSMS address book. It receives a name and phone number and saves them for use in future messaging campaigns.",
+  "example_prompt": "Save a contact to my NimbaSMS address book.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/create_contact/schema.json
+++ b/specs/sms/nimbasms/create_contact/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/contacts"
   },
-  "example_prompt": "Create a new contact in the NimbaSMS address book for use in future messaging campaigns.",
+  "example_prompt": "Write a Node.js function that adds a contact to the NimbaSMS address book. It receives a name and phone number and saves them for use in future messaging campaigns.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/create_contact/schema.json
+++ b/specs/sms/nimbasms/create_contact/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/contacts"
   },
-  "example_prompt": "Save a contact to my NimbaSMS address book.",
+  "example_prompt": "Add a contact to my NimbaSMS address book.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/create_contact/schema.json
+++ b/specs/sms/nimbasms/create_contact/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "basic",
     "location": "header",

--- a/specs/sms/nimbasms/get_balance/schema.json
+++ b/specs/sms/nimbasms/get_balance/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/accounts"
   },
-  "example_prompt": "Write a Node.js function that retrieves the current NimbaSMS credit balance. Call this before sending bulk messages to verify sufficient credits.",
+  "example_prompt": "Check how many SMS credits I have left on NimbaSMS.",
   "input_schema": {
     "type": "object",
     "properties": {}

--- a/specs/sms/nimbasms/get_balance/schema.json
+++ b/specs/sms/nimbasms/get_balance/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/accounts"
   },
-  "example_prompt": "Check how many SMS credits I have left on NimbaSMS.",
+  "example_prompt": "Check my NimbaSMS credit balance.",
   "input_schema": {
     "type": "object",
     "properties": {}

--- a/specs/sms/nimbasms/get_balance/schema.json
+++ b/specs/sms/nimbasms/get_balance/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "get_balance",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -23,6 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/accounts"
   },
+  "example_prompt": "Check the current NimbaSMS account credit balance before sending messages to ensure sufficient funds.",
   "input_schema": {
     "type": "object",
     "properties": {}

--- a/specs/sms/nimbasms/get_balance/schema.json
+++ b/specs/sms/nimbasms/get_balance/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/accounts"
   },
-  "example_prompt": "Check the current NimbaSMS account credit balance before sending messages to ensure sufficient funds.",
+  "example_prompt": "Write a Node.js function that retrieves the current NimbaSMS credit balance. Call this before sending bulk messages to verify sufficient credits.",
   "input_schema": {
     "type": "object",
     "properties": {}

--- a/specs/sms/nimbasms/get_balance/schema.json
+++ b/specs/sms/nimbasms/get_balance/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "basic",
     "location": "header",

--- a/specs/sms/nimbasms/get_message/schema.json
+++ b/specs/sms/nimbasms/get_message/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "get_message",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -23,9 +21,12 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/messages/{id}"
   },
+  "example_prompt": "Retrieve the delivery status of a specific NimbaSMS message using its message ID.",
   "input_schema": {
     "type": "object",
-    "required": ["id"],
+    "required": [
+      "id"
+    ],
     "properties": {
       "id": {
         "type": "string",
@@ -52,7 +53,11 @@
       },
       "status": {
         "type": "string",
-        "enum": ["pending", "sent", "failure"],
+        "enum": [
+          "pending",
+          "sent",
+          "failure"
+        ],
         "description": "Statut global du message."
       },
       "sent_at": {
@@ -69,11 +74,23 @@
         "items": {
           "type": "object",
           "properties": {
-            "id": { "type": "string", "format": "uuid" },
-            "contact": { "type": "string", "description": "Numéro destinataire." },
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "contact": {
+              "type": "string",
+              "description": "Numéro destinataire."
+            },
             "status": {
               "type": "string",
-              "enum": ["tosend", "sent", "received", "failure", "not_available"],
+              "enum": [
+                "tosend",
+                "sent",
+                "received",
+                "failure",
+                "not_available"
+              ],
               "description": "Statut de livraison pour ce destinataire."
             }
           }

--- a/specs/sms/nimbasms/get_message/schema.json
+++ b/specs/sms/nimbasms/get_message/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/messages/{id}"
   },
-  "example_prompt": "Write a Node.js function that retrieves the delivery status of a NimbaSMS message by its message ID.",
+  "example_prompt": "Check the delivery status of an SMS I sent via NimbaSMS.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/get_message/schema.json
+++ b/specs/sms/nimbasms/get_message/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/messages/{id}"
   },
-  "example_prompt": "Retrieve the delivery status of a specific NimbaSMS message using its message ID.",
+  "example_prompt": "Write a Node.js function that retrieves the delivery status of a NimbaSMS message by its message ID.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/get_message/schema.json
+++ b/specs/sms/nimbasms/get_message/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "basic",
     "location": "header",

--- a/specs/sms/nimbasms/list_contacts/schema.json
+++ b/specs/sms/nimbasms/list_contacts/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/contacts"
   },
-  "example_prompt": "List all contacts in my NimbaSMS address book.",
+  "example_prompt": "List contacts in my NimbaSMS address book.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/sms/nimbasms/list_contacts/schema.json
+++ b/specs/sms/nimbasms/list_contacts/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/contacts"
   },
-  "example_prompt": "Write a Node.js function that lists all contacts in the NimbaSMS address book with pagination support.",
+  "example_prompt": "List all contacts in my NimbaSMS address book.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/sms/nimbasms/list_contacts/schema.json
+++ b/specs/sms/nimbasms/list_contacts/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "list_contacts",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -23,6 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/contacts"
   },
+  "example_prompt": "List all contacts stored in the NimbaSMS address book.",
   "input_schema": {
     "type": "object",
     "properties": {
@@ -46,11 +45,17 @@
         "description": "Nombre total de contacts."
       },
       "next": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "URL de la page suivante ou null."
       },
       "previous": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "URL de la page précédente ou null."
       },
       "results": {
@@ -58,11 +63,19 @@
         "items": {
           "type": "object",
           "properties": {
-            "numero": { "type": "string", "description": "Numéro de téléphone du contact." },
-            "name": { "type": "string", "description": "Nom du contact." },
+            "numero": {
+              "type": "string",
+              "description": "Numéro de téléphone du contact."
+            },
+            "name": {
+              "type": "string",
+              "description": "Nom du contact."
+            },
             "groups": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "description": "Groupes auxquels appartient le contact."
             }
           }

--- a/specs/sms/nimbasms/list_contacts/schema.json
+++ b/specs/sms/nimbasms/list_contacts/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/contacts"
   },
-  "example_prompt": "List all contacts stored in the NimbaSMS address book.",
+  "example_prompt": "Write a Node.js function that lists all contacts in the NimbaSMS address book with pagination support.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/sms/nimbasms/list_contacts/schema.json
+++ b/specs/sms/nimbasms/list_contacts/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "basic",
     "location": "header",

--- a/specs/sms/nimbasms/list_groups/schema.json
+++ b/specs/sms/nimbasms/list_groups/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/groups"
   },
-  "example_prompt": "Write a Node.js function that retrieves all contact groups defined in the NimbaSMS account.",
+  "example_prompt": "List my NimbaSMS contact groups.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/sms/nimbasms/list_groups/schema.json
+++ b/specs/sms/nimbasms/list_groups/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "basic",
     "location": "header",

--- a/specs/sms/nimbasms/list_groups/schema.json
+++ b/specs/sms/nimbasms/list_groups/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "list_groups",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -23,6 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/groups"
   },
+  "example_prompt": "List all contact groups defined in the NimbaSMS account.",
   "input_schema": {
     "type": "object",
     "properties": {
@@ -46,11 +45,17 @@
         "description": "Nombre total de groupes."
       },
       "next": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "URL de la page suivante ou null."
       },
       "previous": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "URL de la page précédente ou null."
       },
       "results": {
@@ -58,10 +63,24 @@
         "items": {
           "type": "object",
           "properties": {
-            "groupe_id": { "type": "string", "format": "uuid", "description": "Identifiant unique du groupe." },
-            "name": { "type": "string", "maxLength": 100, "description": "Nom du groupe." },
-            "added_at": { "type": "string", "description": "Date d'ajout du groupe." },
-            "total_contact": { "type": "integer", "description": "Nombre de contacts dans le groupe." }
+            "groupe_id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Identifiant unique du groupe."
+            },
+            "name": {
+              "type": "string",
+              "maxLength": 100,
+              "description": "Nom du groupe."
+            },
+            "added_at": {
+              "type": "string",
+              "description": "Date d'ajout du groupe."
+            },
+            "total_contact": {
+              "type": "integer",
+              "description": "Nombre de contacts dans le groupe."
+            }
           }
         }
       }

--- a/specs/sms/nimbasms/list_groups/schema.json
+++ b/specs/sms/nimbasms/list_groups/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/groups"
   },
-  "example_prompt": "List all contact groups defined in the NimbaSMS account.",
+  "example_prompt": "Write a Node.js function that retrieves all contact groups defined in the NimbaSMS account.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/sms/nimbasms/list_messages/schema.json
+++ b/specs/sms/nimbasms/list_messages/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "list_messages",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -23,6 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/messages"
   },
+  "example_prompt": "List messages sent via NimbaSMS, optionally filtered by date range or status.",
   "input_schema": {
     "type": "object",
     "properties": {
@@ -61,11 +60,17 @@
         "description": "Nombre total de messages disponibles."
       },
       "next": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "URL de la page suivante ou null si dernière page."
       },
       "previous": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "URL de la page précédente ou null si première page."
       },
       "results": {
@@ -73,12 +78,29 @@
         "items": {
           "type": "object",
           "properties": {
-            "id": { "type": "string", "format": "uuid" },
-            "status": { "type": "string" },
-            "to": { "type": "array", "items": { "type": "string" } },
-            "message": { "type": "string" },
-            "sender_name": { "type": "string" },
-            "sent_at": { "type": "string", "format": "date-time" },
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "status": {
+              "type": "string"
+            },
+            "to": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "message": {
+              "type": "string"
+            },
+            "sender_name": {
+              "type": "string"
+            },
+            "sent_at": {
+              "type": "string",
+              "format": "date-time"
+            },
             "message_cost": {
               "type": "integer",
               "readOnly": true,

--- a/specs/sms/nimbasms/list_messages/schema.json
+++ b/specs/sms/nimbasms/list_messages/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/messages"
   },
-  "example_prompt": "List messages sent via NimbaSMS, optionally filtered by date range or status.",
+  "example_prompt": "Write a Node.js function that lists NimbaSMS messages sent within a date range. Use this to audit outbound SMS.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/sms/nimbasms/list_messages/schema.json
+++ b/specs/sms/nimbasms/list_messages/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "basic",
     "location": "header",

--- a/specs/sms/nimbasms/list_messages/schema.json
+++ b/specs/sms/nimbasms/list_messages/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/messages"
   },
-  "example_prompt": "Write a Node.js function that lists NimbaSMS messages sent within a date range. Use this to audit outbound SMS.",
+  "example_prompt": "List SMS messages I sent this week via NimbaSMS.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/sms/nimbasms/list_sendernames/schema.json
+++ b/specs/sms/nimbasms/list_sendernames/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/sendernames"
   },
-  "example_prompt": "Retrieve all approved sender names available for the NimbaSMS account before sending a message.",
+  "example_prompt": "Write a Node.js function that retrieves the approved sender names for the NimbaSMS account. Always call this first to pick a valid sender_name before sending a message.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/sms/nimbasms/list_sendernames/schema.json
+++ b/specs/sms/nimbasms/list_sendernames/schema.json
@@ -21,7 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/sendernames"
   },
-  "example_prompt": "Write a Node.js function that retrieves the approved sender names for the NimbaSMS account. Always call this first to pick a valid sender_name before sending a message.",
+  "example_prompt": "Get the sender names I'm allowed to use on NimbaSMS.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/specs/sms/nimbasms/list_sendernames/schema.json
+++ b/specs/sms/nimbasms/list_sendernames/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "basic",
     "location": "header",

--- a/specs/sms/nimbasms/list_sendernames/schema.json
+++ b/specs/sms/nimbasms/list_sendernames/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "list_sendernames",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -23,6 +21,7 @@
     "method": "GET",
     "url": "https://api.nimbasms.com/v1/sendernames"
   },
+  "example_prompt": "Retrieve all approved sender names available for the NimbaSMS account before sending a message.",
   "input_schema": {
     "type": "object",
     "properties": {
@@ -46,11 +45,17 @@
         "description": "Nombre total de sender names."
       },
       "next": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "URL de la page suivante ou null."
       },
       "previous": {
-        "type": ["string", "null"],
+        "type": [
+          "string",
+          "null"
+        ],
         "description": "URL de la page précédente ou null."
       },
       "results": {
@@ -58,14 +63,28 @@
         "items": {
           "type": "object",
           "properties": {
-            "sendername_id": { "type": "string", "format": "uuid", "description": "Identifiant unique du sender name." },
-            "name": { "type": "string", "description": "Nom d'expéditeur." },
+            "sendername_id": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Identifiant unique du sender name."
+            },
+            "name": {
+              "type": "string",
+              "description": "Nom d'expéditeur."
+            },
             "status": {
               "type": "string",
-              "enum": ["pending", "refused", "accepted"],
+              "enum": [
+                "pending",
+                "refused",
+                "accepted"
+              ],
               "description": "Statut du sender name. Seul 'accepted' peut être utilisé dans send_message et send_verification."
             },
-            "added_at": { "type": "integer", "description": "Date d'ajout en Unix timestamp (secondes)." }
+            "added_at": {
+              "type": "integer",
+              "description": "Date d'ajout en Unix timestamp (secondes)."
+            }
           }
         }
       }

--- a/specs/sms/nimbasms/provider.json
+++ b/specs/sms/nimbasms/provider.json
@@ -2,7 +2,13 @@
   "slug": "nimbasms",
   "name": "NimbaSMS",
   "category": "sms",
-  "country_code": ["GN"],
+  "country_code": [
+    "GN"
+  ],
+  "website": "https://nimbasms.com",
+  "docs_url": "https://developers.nimbasms.com/",
+  "docs_public": true,
+  "sandbox": false,
   "description": "NimbaSMS is a Guinean professional messaging platform supporting SMS, WhatsApp, and email delivery from a single API with contact and group management.",
   "example_prompt": "Add SMS verification to my app using NimbaSMS."
 }

--- a/specs/sms/nimbasms/provider.json
+++ b/specs/sms/nimbasms/provider.json
@@ -4,5 +4,5 @@
   "category": "sms",
   "country_code": ["GN"],
   "description": "NimbaSMS is a Guinean professional messaging platform supporting SMS, WhatsApp, and email delivery from a single API with contact and group management.",
-  "example_prompt": "I need to verify my users' phone numbers via SMS using NimbaSMS."
+  "example_prompt": "Add SMS verification to my app using NimbaSMS."
 }

--- a/specs/sms/nimbasms/provider.json
+++ b/specs/sms/nimbasms/provider.json
@@ -4,5 +4,5 @@
   "category": "sms",
   "country_code": ["GN"],
   "description": "NimbaSMS is a Guinean professional messaging platform supporting SMS, WhatsApp, and email delivery from a single API with contact and group management.",
-  "example_prompt": "Use NimbaSMS to send an OTP verification code to a Guinean phone number, then verify the code entered by the user to complete authentication."
+  "example_prompt": "Add SMS phone verification to my app using NimbaSMS. Write a flow that sends an OTP code to a user's Guinean phone number, then verifies the code they enter before granting access."
 }

--- a/specs/sms/nimbasms/provider.json
+++ b/specs/sms/nimbasms/provider.json
@@ -1,0 +1,8 @@
+{
+  "slug": "nimbasms",
+  "name": "NimbaSMS",
+  "category": "sms",
+  "country_code": ["GN"],
+  "description": "NimbaSMS is a Guinean professional messaging platform supporting SMS, WhatsApp, and email delivery from a single API with contact and group management.",
+  "example_prompt": "Use NimbaSMS to send an OTP verification code to a Guinean phone number, then verify the code entered by the user to complete authentication."
+}

--- a/specs/sms/nimbasms/provider.json
+++ b/specs/sms/nimbasms/provider.json
@@ -4,5 +4,5 @@
   "category": "sms",
   "country_code": ["GN"],
   "description": "NimbaSMS is a Guinean professional messaging platform supporting SMS, WhatsApp, and email delivery from a single API with contact and group management.",
-  "example_prompt": "Add SMS phone verification to my app using NimbaSMS. Write a flow that sends an OTP code to a user's Guinean phone number, then verifies the code they enter before granting access."
+  "example_prompt": "I need to verify my users' phone numbers via SMS using NimbaSMS."
 }

--- a/specs/sms/nimbasms/send_message/schema.json
+++ b/specs/sms/nimbasms/send_message/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/messages"
   },
-  "example_prompt": "Send an SMS to one or more Guinean phone numbers via NimbaSMS, specifying the sender name and message content.",
+  "example_prompt": "Write a Node.js function that sends an SMS via NimbaSMS. It receives a recipient phone number, message text, and sender name, and returns the message ID for delivery tracking.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/send_message/schema.json
+++ b/specs/sms/nimbasms/send_message/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/messages"
   },
-  "example_prompt": "Send an SMS to a Guinean phone number via NimbaSMS.",
+  "example_prompt": "Add SMS sending to my app via NimbaSMS.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/send_message/schema.json
+++ b/specs/sms/nimbasms/send_message/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "send_message",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -23,13 +21,21 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/messages"
   },
+  "example_prompt": "Send an SMS to one or more Guinean phone numbers via NimbaSMS, specifying the sender name and message content.",
   "input_schema": {
     "type": "object",
-    "required": ["to", "message", "sender_name"],
+    "required": [
+      "to",
+      "message",
+      "sender_name"
+    ],
     "properties": {
       "to": {
         "type": "array",
-        "items": { "type": "string", "maxLength": 15 },
+        "items": {
+          "type": "string",
+          "maxLength": 15
+        },
         "minItems": 1,
         "maxItems": 30,
         "description": "Numéros destinataires. Trois formats acceptés : local (623XXXXXX), avec indicatif (224623XXXXXX), ou E.164 (+224623XXXXXX). Maximum 30 contacts par requête."
@@ -46,7 +52,11 @@
       },
       "channel": {
         "type": "string",
-        "enum": ["sms", "whatsapp", "email"],
+        "enum": [
+          "sms",
+          "whatsapp",
+          "email"
+        ],
         "default": "sms",
         "description": "Canal d'envoi. Défaut: 'sms'."
       }
@@ -54,7 +64,11 @@
   },
   "response_schema": {
     "type": "object",
-    "required": ["messageid", "message_cost", "url"],
+    "required": [
+      "messageid",
+      "message_cost",
+      "url"
+    ],
     "properties": {
       "messageid": {
         "type": "string",

--- a/specs/sms/nimbasms/send_message/schema.json
+++ b/specs/sms/nimbasms/send_message/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/messages"
   },
-  "example_prompt": "Write a Node.js function that sends an SMS via NimbaSMS. It receives a recipient phone number, message text, and sender name, and returns the message ID for delivery tracking.",
+  "example_prompt": "Send an SMS to a Guinean phone number via NimbaSMS.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/send_message/schema.json
+++ b/specs/sms/nimbasms/send_message/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "basic",
     "location": "header",

--- a/specs/sms/nimbasms/send_verification/schema.json
+++ b/specs/sms/nimbasms/send_verification/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/verifications"
   },
-  "example_prompt": "Send an OTP to my user's phone number to verify it.",
+  "example_prompt": "Add phone number verification via SMS to my signup flow.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/send_verification/schema.json
+++ b/specs/sms/nimbasms/send_verification/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "send_verification",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -23,9 +21,13 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/verifications"
   },
+  "example_prompt": "Send a one-time OTP code to a user's phone number via NimbaSMS for authentication purposes.",
   "input_schema": {
     "type": "object",
-    "required": ["to", "sender_name"],
+    "required": [
+      "to",
+      "sender_name"
+    ],
     "properties": {
       "to": {
         "type": "string",
@@ -39,7 +41,11 @@
       },
       "channel": {
         "type": "string",
-        "enum": ["sms", "whatsapp", "email"],
+        "enum": [
+          "sms",
+          "whatsapp",
+          "email"
+        ],
         "default": "sms",
         "description": "Canal d'envoi. Défaut: 'sms'."
       },
@@ -49,13 +55,19 @@
         "description": "Modèle du message. Doit contenir le placeholder <1234> qui sera remplacé par le code. Défaut: 'Code de confirmation Nimba SMS <1234>'. Pour WhatsApp, le contenu est remplacé selon le template."
       },
       "expiry_time": {
-        "type": ["integer", "null"],
+        "type": [
+          "integer",
+          "null"
+        ],
         "minimum": 5,
         "maximum": 30,
         "description": "Durée de validité du code en minutes. Entre 5 et 30 (inclus). null par défaut."
       },
       "attempts": {
-        "type": ["integer", "null"],
+        "type": [
+          "integer",
+          "null"
+        ],
         "minimum": 3,
         "maximum": 10,
         "description": "Nombre maximum de tentatives avant expiration. Entre 3 et 10 (inclus). null par défaut."
@@ -101,27 +113,37 @@
       },
       "to": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Erreurs de validation sur le champ 'to'."
       },
       "sender_name": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Erreurs de validation sur le champ 'sender_name'."
       },
       "expiry_time": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Erreurs de validation sur le champ 'expiry_time' (valeur hors plage 5-30)."
       },
       "attempts": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Erreurs de validation sur le champ 'attempts' (valeur hors plage 3-10)."
       },
       "code_length": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Erreurs de validation sur le champ 'code_length' (valeur hors plage 4-8)."
       }
     }

--- a/specs/sms/nimbasms/send_verification/schema.json
+++ b/specs/sms/nimbasms/send_verification/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/verifications"
   },
-  "example_prompt": "Send a one-time OTP code to a user's phone number via NimbaSMS for authentication purposes.",
+  "example_prompt": "Write a Node.js function that sends an OTP to a user's phone number via NimbaSMS. It returns the verification ID needed to call verify_code.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/send_verification/schema.json
+++ b/specs/sms/nimbasms/send_verification/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "basic",
     "location": "header",

--- a/specs/sms/nimbasms/send_verification/schema.json
+++ b/specs/sms/nimbasms/send_verification/schema.json
@@ -21,7 +21,7 @@
     "method": "POST",
     "url": "https://api.nimbasms.com/v1/verifications"
   },
-  "example_prompt": "Write a Node.js function that sends an OTP to a user's phone number via NimbaSMS. It returns the verification ID needed to call verify_code.",
+  "example_prompt": "Send an OTP to my user's phone number to verify it.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/verify_code/schema.json
+++ b/specs/sms/nimbasms/verify_code/schema.json
@@ -21,7 +21,7 @@
     "method": "PATCH",
     "url": "https://api.nimbasms.com/v1/verifications/{id}"
   },
-  "example_prompt": "Check if the OTP my user entered is correct.",
+  "example_prompt": "Verify the OTP my user entered during phone verification.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/verify_code/schema.json
+++ b/specs/sms/nimbasms/verify_code/schema.json
@@ -21,7 +21,7 @@
     "method": "PATCH",
     "url": "https://api.nimbasms.com/v1/verifications/{id}"
   },
-  "example_prompt": "Write a Node.js function that verifies an OTP entered by the user. It receives the verification ID and the code submitted by the user, calls NimbaSMS verify_code, and returns whether authentication succeeded.",
+  "example_prompt": "Check if the OTP my user entered is correct.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/verify_code/schema.json
+++ b/specs/sms/nimbasms/verify_code/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "verify_code",
   "capability_type": "synchronous",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -23,9 +21,13 @@
     "method": "PATCH",
     "url": "https://api.nimbasms.com/v1/verifications/{id}"
   },
+  "example_prompt": "Verify an OTP code entered by the user against the one sent via NimbaSMS send_verification.",
   "input_schema": {
     "type": "object",
-    "required": ["id", "code"],
+    "required": [
+      "id",
+      "code"
+    ],
     "properties": {
       "id": {
         "type": "string",
@@ -45,7 +47,16 @@
     "properties": {
       "status": {
         "type": "string",
-        "enum": ["pending", "sent", "expired", "failure", "received", "too_many_attemps", "approved", "read"],
+        "enum": [
+          "pending",
+          "sent",
+          "expired",
+          "failure",
+          "received",
+          "too_many_attemps",
+          "approved",
+          "read"
+        ],
         "description": "Statut de la vérification après tentative. 'approved' = code correct. 'too_many_attemps' = tentatives épuisées (typo dans l'API, un seul 't' à 'attempts')."
       }
     }
@@ -59,7 +70,9 @@
       },
       "code": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Erreurs de validation sur le champ 'code'."
       }
     }

--- a/specs/sms/nimbasms/verify_code/schema.json
+++ b/specs/sms/nimbasms/verify_code/schema.json
@@ -21,7 +21,7 @@
     "method": "PATCH",
     "url": "https://api.nimbasms.com/v1/verifications/{id}"
   },
-  "example_prompt": "Verify an OTP code entered by the user against the one sent via NimbaSMS send_verification.",
+  "example_prompt": "Write a Node.js function that verifies an OTP entered by the user. It receives the verification ID and the code submitted by the user, calls NimbaSMS verify_code, and returns whether authentication succeeded.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/verify_code/schema.json
+++ b/specs/sms/nimbasms/verify_code/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "basic",
     "location": "header",

--- a/specs/sms/nimbasms/webhook_sms_status/schema.json
+++ b/specs/sms/nimbasms/webhook_sms_status/schema.json
@@ -1,14 +1,12 @@
 {
   "spec_version": "1.0",
-  "provider_slug": "nimbasms",
-  "provider_name": "NimbaSMS",
   "provider_api_version": "2024-01-01",
-  "category": "sms",
   "capability": "webhook_sms_status",
   "capability_type": "webhook",
-  "status": "compliant",
-  "country_code": ["GN"],
-  "currency": ["GNF"],
+  "status": "ready",
+  "currency": [
+    "GNF"
+  ],
   "sandbox": false,
   "docs_url": "https://developers.nimbasms.com/",
   "docs_public": true,
@@ -20,9 +18,14 @@
     "method": "POST",
     "url": "https://your-app.com/webhooks/sms-status"
   },
+  "example_prompt": "Handle an incoming NimbaSMS webhook to receive delivery status updates for previously sent messages.",
   "input_schema": {
     "type": "object",
-    "required": ["messageid", "contact", "metadata"],
+    "required": [
+      "messageid",
+      "contact",
+      "metadata"
+    ],
     "properties": {
       "messageid": {
         "type": "string",
@@ -31,7 +34,10 @@
       },
       "status": {
         "type": "string",
-        "enum": ["received", "failed"],
+        "enum": [
+          "received",
+          "failed"
+        ],
         "default": "received",
         "description": "Nouveau statut du message. 'received' = livré au destinataire, 'failed' = échec de livraison."
       },
@@ -42,11 +48,15 @@
       },
       "metadata": {
         "type": "object",
-        "required": ["message_type"],
+        "required": [
+          "message_type"
+        ],
         "properties": {
           "message_type": {
             "type": "string",
-            "enum": ["API"],
+            "enum": [
+              "API"
+            ],
             "description": "Type de message. Toujours 'API' pour les envois via l'API."
           }
         }

--- a/specs/sms/nimbasms/webhook_sms_status/schema.json
+++ b/specs/sms/nimbasms/webhook_sms_status/schema.json
@@ -7,9 +7,6 @@
   "currency": [
     "GNF"
   ],
-  "sandbox": false,
-  "docs_url": "https://developers.nimbasms.com/",
-  "docs_public": true,
   "auth": {
     "type": "none",
     "env_var": "NIMBASMS_SERVICE_ID"

--- a/specs/sms/nimbasms/webhook_sms_status/schema.json
+++ b/specs/sms/nimbasms/webhook_sms_status/schema.json
@@ -18,7 +18,7 @@
     "method": "POST",
     "url": "https://your-app.com/webhooks/sms-status"
   },
-  "example_prompt": "Write an Express route POST /webhooks/nimbasms that receives NimbaSMS delivery status updates and persists the final delivery state for each message ID.",
+  "example_prompt": "Handle NimbaSMS delivery status updates for messages I sent.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/webhook_sms_status/schema.json
+++ b/specs/sms/nimbasms/webhook_sms_status/schema.json
@@ -18,7 +18,7 @@
     "method": "POST",
     "url": "https://your-app.com/webhooks/sms-status"
   },
-  "example_prompt": "Handle NimbaSMS delivery status updates for messages I sent.",
+  "example_prompt": "Add a NimbaSMS delivery status webhook to track message delivery in my app.",
   "input_schema": {
     "type": "object",
     "required": [

--- a/specs/sms/nimbasms/webhook_sms_status/schema.json
+++ b/specs/sms/nimbasms/webhook_sms_status/schema.json
@@ -18,7 +18,7 @@
     "method": "POST",
     "url": "https://your-app.com/webhooks/sms-status"
   },
-  "example_prompt": "Handle an incoming NimbaSMS webhook to receive delivery status updates for previously sent messages.",
+  "example_prompt": "Write an Express route POST /webhooks/nimbasms that receives NimbaSMS delivery status updates and persists the final delivery state for each message ID.",
   "input_schema": {
     "type": "object",
     "required": [


### PR DESCRIPTION
## Summary

- **Section 1** — Renommage `compliant` → `ready` dans les 41 specs + validateur + ATSS.md
- **Section 2** — Nouveau `provider.json` par provider (slug, name, category, country_code, description, example_prompt) ; champs migrés supprimés de `schema.json`
- **Section 3** — `example_prompt` ajouté dans chaque `schema.json` (par capability) ; validateur l'exige pour status `ready`
- **Section 4** — Pipeline cascade : step `repository_dispatch` vers `afrotools/mcp` après validation réussie sur main
- **Section 6** — Issue template "API Changed Report"

## Changements clés

- `validate.js` : accepte `ready`, rejette `compliant`, valide `provider.json`, rejette les champs migrés
- `ATSS.md` : nouvelle structure de dossier, champs `provider.json`, lifecycle mis à jour, provider index à jour
- 41 `schema.json` : status renommé, `example_prompt` ajouté, champs provider supprimés
- 5 `provider.json` créés : paycard, djomy, lengopay, wave, nimbasms

## Test plan

- [ ] `npm run validate` passe (41/41)
- [ ] Aucun `schema.json` ne contient `provider_slug`, `provider_name`, `category`, `country_code`
- [ ] Aucun `schema.json` ne contient `status: compliant`
- [ ] `provider.json` présent pour chaque provider actif
- [ ] `DISPATCH_TOKEN` secret configuré dans les settings du repo avant merge