### PR TITLE
fix(wave): correct docs_url to docs.wave.com/business

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
 
+  # Regenerate README providers table — only on push to main, after validate passes
+  generate-readme:
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Generate README tables
+        run: node scripts/generate-readme.js
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet || (git add README.md && git commit -m "chore: update providers table" && git push)
+
   # Security scan + CodeQL — only when specs/** changed
   security:
     needs: changes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Afro.tools — AI-ready infrastructure for African APIs
 
+> Integrate Wave, Paycard, or Orange Money in a single prompt.
+
 African APIs are production-grade. What's been missing is a standard,
 machine-readable format that AI agents can consume directly — without
 parsing documentation pages or guessing at request shapes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Afro.tools — AI-ready infrastructure for African APIs
 
-> Integrate Wave, Paycard, or Orange Money in a single prompt.
+> Integrate Wave, Paycard, and any African API in a single prompt.
 
 African APIs are production-grade. What's been missing is a standard,
 machine-readable format that AI agents can consume directly — without

--- a/README.md
+++ b/README.md
@@ -1,91 +1,77 @@
 # Afro.tools — AI-ready infrastructure for African APIs
 
-African APIs are production-grade. What's been missing is a standard, machine-readable format that lets AI coding agents consume them directly — without parsing documentation pages or guessing at request shapes.
+African APIs sont production-grade. Ce qui manquait : un format
+machine-readable standardisé que les agents IA peuvent consommer
+directement — sans parser des pages de documentation ni deviner
+les shapes de requêtes.
 
-Afro.tools fills that gap: a static, open-source registry of structured API specs for African APIs — payments, SMS, identity, logistics, and beyond. Each spec is verified against the live API and exposes exactly what an AI agent needs to generate correct integration code on the first try.
-
-**Built for:**
-- Developers integrating African APIs into their apps
-- AI coding assistants (Claude, Cursor, Copilot, and others) that need reliable specs to generate code
-- Contributors who want to document providers they've integrated
+Afro.tools comble ce vide : un registre statique, open source,
+de specs structurées pour les APIs africaines. Chaque spec est
+vérifiée contre l'API réelle et expose exactement ce qu'un agent
+IA a besoin pour générer du code d'intégration correct du premier coup.
 
 ---
 
-## How it works
+## Comment ça marche
 
 ```mermaid
 graph LR
     A["specs/ — open source"] -->|GitHub raw URLs| B["MCP server\nmcp.afro.tools"]
-    B -->|MCP protocol| C["AI agent\nClaude · Cursor · Copilot · ..."]
-    C -->|generates| D["Integration code\nin your app"]
+    B -->|MCP protocol| C["Agent IA\nClaude · Cursor · Copilot · ..."]
+    C -->|génère| D["Code d'intégration\ndans ton app"]
     A -->|plugin| C
 ```
 
 ---
 
-## What is a spec?
+## Qu'est-ce qu'une spec ?
 
-A spec lives at `specs/{category}/{provider}/{capability}/` and contains exactly two files:
+Une spec vit dans `specs/{category}/{provider}/{capability}/` et contient deux fichiers :
 
-- **`schema.json`** — ATSS-compliant description of the API capability (endpoint, auth, input/output schemas, gotchas)
-- **`canonical_example.ts`** — TypeScript implementation using native fetch, compiles with `tsc --noEmit`
+- **`schema.json`** — description ATSS-compliant de la capability API (endpoint, auth, input/output schemas, gotchas)
+- **`canonical_example.ts`** — implémentation TypeScript avec native fetch, compile avec `tsc --noEmit`
 
-See [ATSS.md](./ATSS.md) for the full specification.
+Chaque provider a aussi un **`provider.json`** à la racine de son dossier :
+
+```
+specs/payment/paycard/
+├── provider.json                    ← metadata + description + example_prompt global
+├── create_payment/
+│   ├── schema.json
+│   └── canonical_example.ts
+├── verify_payment/
+└── webhook_payment_completed/
+```
+
+Voir [ATSS.md](./ATSS.md) pour la spécification complète.
 
 ---
 
 ## Providers
 
-| Provider | Category | Country | Capabilities | Status |
-|---|---|---|---|---|
-| Paycard | payment | GN | create_payment, verify_payment, webhook_payment_completed | ✅ Verified |
-| LengoPay | payment | GN | create_payment, verify_payment, webhook_payment_completed | ✅ Verified |
-| Wave | payment | SN, CI, ML | create_payment, verify_payment, webhook_payment_completed | Planned |
-| Djomy | payment | GN | create_payment, verify_payment | Planned |
-| Bictorys | payment | — | create_payment, verify_payment, webhook_payment_completed | Planned |
-| NimbaSMS | sms | GN | send_otp, send_bulk | Planned |
+<!-- tableau généré automatiquement par le pipeline — ne pas éditer manuellement -->
+| Provider | Catégorie | Pays | Capabilities | Statut |
+|----------|-----------|------|-------------|--------|
+| Paycard | payment | 🇬🇳 | 3 | ✅ AI Ready |
+| Djomy | payment | 🇬🇳 | 7 | 4 verified · 3 ready |
+| LengoPay | payment | 🇬🇳 | 8 | 2 verified · 6 ready |
+| NimbaSMS | sms | 🇬🇳 | 11 | 📋 Ready |
+| Wave | payment | 🇸🇳 🇨🇮 🇲🇱 +8 | 12 | 📋 Ready |
+<!-- fin du tableau -->
+
+**Légende :** ✅ AI Ready = toutes les capabilities `verified` · X verified · Y ready = en attente de validation en prod · 📋 Ready = spec validée · 🗓 Planifié = specs à venir
 
 ---
 
-## Use with an MCP client
+## Utiliser avec un client MCP
 
-Add to your MCP client configuration:
-
-### Claude Desktop (`claude_desktop_config.json`)
-
-```json
-{
-  "mcpServers": {
-    "afrotools": {
-      "type": "http",
-      "url": "https://mcp.afro.tools/mcp"
-    }
-  }
-}
-```
-
-### Cursor / Windsurf / other editors
-
-```json
-{
-  "mcp": {
-    "servers": {
-      "afrotools": {
-        "type": "http",
-        "url": "https://mcp.afro.tools/mcp"
-      }
-    }
-  }
-}
-```
-
-### Claude Code (CLI)
+### Claude Code
 
 ```bash
 claude mcp add --transport http afrotools https://mcp.afro.tools/mcp
 ```
 
-Or add to your project's `.mcp.json`:
+### Cursor / Windsurf / VS Code Copilot
 
 ```json
 {
@@ -100,53 +86,35 @@ Or add to your project's `.mcp.json`:
 
 ---
 
-## Claude Code plugin
+## Plugin Claude Code
 
-Install the plugin to get Afro.tools skills directly in your editor:
-
-```text
+```
 /plugin marketplace add afrotools/afrotools
 /plugin install afrotools
 ```
 
-The plugin includes:
+**Skills auto-activés** selon le contexte :
+- `payment` — intégration d'une API de paiement
+- `sms` — intégration d'une API SMS
+- `debug` — quand une intégration basée sur une spec afrotools échoue → diagnostique si le problème vient de la spec, d'un gotcha manquant ou d'un changement d'API non documenté
 
-**Auto-activated skills** (trigger automatically based on your request):
-
-- **`payment`** — integrating a payment API → fetches the right spec before writing any code
-- **`sms`** — integrating an SMS API → same
-- **`debug`** — debugging a failing integration → cross-checks your code against the spec and gotchas
-
-**Manual commands:**
-
-- **`/afrotools:spec <provider> <capability>`** — inspect the full spec for a provider/capability
-- **`/afrotools:list`** — list all available specs with their status
-- **`/afrotools:new <category> <provider> <capability>`** — scaffold a new spec (for contributors)
+**Commandes manuelles :**
+- `/afrotools:spec <provider> <capability>` — inspecter une spec complète
+- `/afrotools:list` — lister toutes les specs disponibles
+- `/afrotools:new <category> <provider> <capability>` — scaffolder une nouvelle spec
 
 ---
 
-## Standalone SKILL.md
+## Contribuer
 
-If you don't use the plugin, you can copy a single `SKILL.md` into your project:
+Voir [CONTRIBUTING.md](./CONTRIBUTING.md) pour ajouter une spec ou améliorer une existante.
 
-```text
-plugin/skills/payment/SKILL.md   ← for payment integrations
-plugin/skills/sms/SKILL.md       ← for SMS integrations
-```
+Lifecycle des specs : `draft → ready → verified`
 
-Place it in your project's `.claude/skills/` directory and Claude Code will pick it up automatically.
+Un provider affiche le badge **AI Ready** quand toutes ses capabilities sont `verified`.
 
 ---
 
-## Contributing
+## Licence
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) to add a spec or improve an existing one.
-
-All specs go through a lifecycle: `draft → compliant → verified`.
-A provider is **AI Ready** when all its capabilities reach `verified`.
-
----
-
-## License
-
-Apache 2.0 — see [LICENSE](./LICENSE).
+Apache 2.0 — voir [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,41 +1,40 @@
 # Afro.tools — AI-ready infrastructure for African APIs
 
-African APIs sont production-grade. Ce qui manquait : un format
-machine-readable standardisé que les agents IA peuvent consommer
-directement — sans parser des pages de documentation ni deviner
-les shapes de requêtes.
+African APIs are production-grade. What's been missing is a standard,
+machine-readable format that AI agents can consume directly — without
+parsing documentation pages or guessing at request shapes.
 
-Afro.tools comble ce vide : un registre statique, open source,
-de specs structurées pour les APIs africaines. Chaque spec est
-vérifiée contre l'API réelle et expose exactement ce qu'un agent
-IA a besoin pour générer du code d'intégration correct du premier coup.
+Afro.tools fills that gap: a static, open-source registry of structured
+specs for African APIs. Each spec is verified against the live API and
+exposes exactly what an AI agent needs to generate correct integration
+code on the first try.
 
 ---
 
-## Comment ça marche
+## How it works
 
 ```mermaid
 graph LR
     A["specs/ — open source"] -->|GitHub raw URLs| B["MCP server\nmcp.afro.tools"]
-    B -->|MCP protocol| C["Agent IA\nClaude · Cursor · Copilot · ..."]
-    C -->|génère| D["Code d'intégration\ndans ton app"]
+    B -->|MCP protocol| C["AI agent\nClaude · Cursor · Copilot · ..."]
+    C -->|generates| D["Integration code\nin your app"]
     A -->|plugin| C
 ```
 
 ---
 
-## Qu'est-ce qu'une spec ?
+## What is a spec?
 
-Une spec vit dans `specs/{category}/{provider}/{capability}/` et contient deux fichiers :
+A spec lives at `specs/{category}/{provider}/{capability}/` and contains exactly two files:
 
-- **`schema.json`** — description ATSS-compliant de la capability API (endpoint, auth, input/output schemas, gotchas)
-- **`canonical_example.ts`** — implémentation TypeScript avec native fetch, compile avec `tsc --noEmit`
+- **`schema.json`** — ATSS-compliant description of the API capability (endpoint, auth, input/output schemas, gotchas)
+- **`canonical_example.ts`** — TypeScript implementation using native fetch, compiles with `tsc --noEmit`
 
-Chaque provider a aussi un **`provider.json`** à la racine de son dossier :
+Each provider also has a **`provider.json`** at the root of its folder:
 
 ```
 specs/payment/paycard/
-├── provider.json                    ← metadata + description + example_prompt global
+├── provider.json                    ← metadata + description + example_prompt
 ├── create_payment/
 │   ├── schema.json
 │   └── canonical_example.ts
@@ -43,15 +42,15 @@ specs/payment/paycard/
 └── webhook_payment_completed/
 ```
 
-Voir [ATSS.md](./ATSS.md) pour la spécification complète.
+See [ATSS.md](./ATSS.md) for the full specification.
 
 ---
 
 ## Providers
 
 <!-- tableau généré automatiquement par le pipeline — ne pas éditer manuellement -->
-| Provider | Catégorie | Pays | Capabilities | Statut |
-|----------|-----------|------|-------------|--------|
+| Provider | Category | Country | Capabilities | Status |
+|----------|----------|---------|--------------|--------|
 | Paycard | payment | 🇬🇳 | 3 | ✅ AI Ready |
 | Djomy | payment | 🇬🇳 | 7 | 4 verified · 3 ready |
 | LengoPay | payment | 🇬🇳 | 8 | 2 verified · 6 ready |
@@ -59,11 +58,11 @@ Voir [ATSS.md](./ATSS.md) pour la spécification complète.
 | Wave | payment | 🇸🇳 🇨🇮 🇲🇱 +8 | 12 | 📋 Ready |
 <!-- fin du tableau -->
 
-**Légende :** ✅ AI Ready = toutes les capabilities `verified` · X verified · Y ready = en attente de validation en prod · 📋 Ready = spec validée · 🗓 Planifié = specs à venir
+**Legend:** ✅ AI Ready = all capabilities `verified` · X verified · Y ready = awaiting production validation · 📋 Ready = spec validated · 🗓 Planned = specs coming soon
 
 ---
 
-## Utiliser avec un client MCP
+## Use with an MCP client
 
 ### Claude Code
 
@@ -86,35 +85,35 @@ claude mcp add --transport http afrotools https://mcp.afro.tools/mcp
 
 ---
 
-## Plugin Claude Code
+## Claude Code plugin
 
 ```
 /plugin marketplace add afrotools/afrotools
 /plugin install afrotools
 ```
 
-**Skills auto-activés** selon le contexte :
-- `payment` — intégration d'une API de paiement
-- `sms` — intégration d'une API SMS
-- `debug` — quand une intégration basée sur une spec afrotools échoue → diagnostique si le problème vient de la spec, d'un gotcha manquant ou d'un changement d'API non documenté
+**Auto-activated skills** based on context:
+- `payment` — integrating a payment API
+- `sms` — integrating an SMS API
+- `debug` — when an integration based on an afrotools spec fails → diagnoses whether the problem is a spec error, a missing gotcha, or an undocumented API change
 
-**Commandes manuelles :**
-- `/afrotools:spec <provider> <capability>` — inspecter une spec complète
-- `/afrotools:list` — lister toutes les specs disponibles
-- `/afrotools:new <category> <provider> <capability>` — scaffolder une nouvelle spec
-
----
-
-## Contribuer
-
-Voir [CONTRIBUTING.md](./CONTRIBUTING.md) pour ajouter une spec ou améliorer une existante.
-
-Lifecycle des specs : `draft → ready → verified`
-
-Un provider affiche le badge **AI Ready** quand toutes ses capabilities sont `verified`.
+**Manual commands:**
+- `/afrotools:spec <provider> <capability>` — inspect a full spec
+- `/afrotools:list` — list all available specs
+- `/afrotools:new <category> <provider> <capability>` — scaffold a new spec
 
 ---
 
-## Licence
+## Contributing
 
-Apache 2.0 — voir [LICENSE](./LICENSE).
+See [CONTRIBUTING.md](./CONTRIBUTING.md) to add a spec or improve an existing one.
+
+Spec lifecycle: `draft → ready → verified`
+
+A provider earns the **AI Ready** badge when all its capabilities reach `verified`.
+
+---
+
+## License
+
+Apache 2.0 — see [LICENSE](./LICENSE).

--- a/plugin/skills/debug/SKILL.md
+++ b/plugin/skills/debug/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: debug
 description: >
-  Use this skill when the user has a failing or broken Afro.tools integration —
-  wrong status codes, auth errors, webhook not firing, unexpected response fields,
-  or any runtime error from a Paycard, LengoPay, NimbaSMS, or other Afro.tools
-  provider. Activate even if the user just pastes an error without context.
+  Use this skill ONLY when the user has a failing integration that is specifically
+  based on an Afro.tools spec — the user is integrating a provider whose spec exists
+  in the Afro.tools registry (Paycard, LengoPay, Djomy, Wave, NimbaSMS, etc.) and
+  encounters wrong status codes, auth errors, webhook failures, unexpected response
+  fields, or runtime errors. Do NOT activate for generic debugging, non-afrotools
+  providers, or integrations not based on an Afro.tools spec. This skill diagnoses
+  whether the problem is a spec error, a missing gotcha, or an undocumented API change.
 ---
 
 # Afro.tools — Debug skill

--- a/scripts/generate-readme.js
+++ b/scripts/generate-readme.js
@@ -188,8 +188,8 @@ function sortProviders(providers) {
  * @returns {string}
  */
 function buildTable(providers) {
-  const header = "| Provider | Catégorie | Pays | Capabilities | Statut |"
-  const sep = "|----------|-----------|------|-------------|--------|"
+  const header = "| Provider | Category | Country | Capabilities | Status |"
+  const sep = "|----------|----------|---------|--------------|--------|"
 
   const rows = providers.map((p) => {
     const flags = buildFlags(p.country_code)

--- a/scripts/generate-readme.js
+++ b/scripts/generate-readme.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+// @ts-check
+"use strict"
+
+/**
+ * generate-readme.js
+ *
+ * Reads all provider.json and schema.json files from specs/ and generates
+ * the providers table in README.md between the HTML comment markers.
+ *
+ * Usage: node scripts/generate-readme.js
+ */
+
+const fs = require("fs")
+const path = require("path")
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const SPECS_ROOT = path.resolve(__dirname, "../specs")
+const README_PATH = path.resolve(__dirname, "../README.md")
+const START_MARKER =
+  "<!-- tableau généré automatiquement par le pipeline — ne pas éditer manuellement -->"
+const END_MARKER = "<!-- fin du tableau -->"
+const MAX_FLAGS = 3
+
+// Statuses considered "visible" in the registry
+const VISIBLE_STATUSES = new Set(["ready", "compliant", "verified"])
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Convert a 2-letter ISO country code to an emoji flag.
+ * Uses Unicode Regional Indicator Symbols (0x1F1E6 = 🇦).
+ * @param {string} code
+ * @returns {string}
+ */
+function toFlag(code) {
+  return [...code.toUpperCase()]
+    .map((c) => String.fromCodePoint(0x1f1e6 + c.charCodeAt(0) - 65))
+    .join("")
+}
+
+/**
+ * Build a flags string: up to MAX_FLAGS emoji flags, then "+N" if more.
+ * @param {string[]} countryCodes
+ * @returns {string}
+ */
+function buildFlags(countryCodes) {
+  if (!countryCodes || countryCodes.length === 0) return "—"
+  const flags = countryCodes.map(toFlag)
+  if (flags.length <= MAX_FLAGS) return flags.join(" ")
+  const shown = flags.slice(0, MAX_FLAGS)
+  const extra = flags.length - MAX_FLAGS
+  return shown.join(" ") + ` +${extra}`
+}
+
+// ─── Provider discovery ───────────────────────────────────────────────────────
+
+/**
+ * @typedef {{ status: string }} Capability
+ * @typedef {{ name: string, category: string, country_code: string[], capabilities: Capability[] }} ProviderData
+ */
+
+/**
+ * Discover all providers by reading provider.json and schema.json files.
+ * @returns {ProviderData[]}
+ */
+function discoverProviders() {
+  /** @type {ProviderData[]} */
+  const providers = []
+
+  let categories
+  try {
+    categories = fs.readdirSync(SPECS_ROOT)
+  } catch {
+    console.error(`Could not read specs directory: ${SPECS_ROOT}`)
+    process.exit(1)
+  }
+
+  for (const category of categories) {
+    const categoryDir = path.join(SPECS_ROOT, category)
+    if (!fs.statSync(categoryDir).isDirectory()) continue
+
+    let providerSlugs
+    try {
+      providerSlugs = fs.readdirSync(categoryDir)
+    } catch {
+      continue
+    }
+
+    for (const slug of providerSlugs) {
+      const providerDir = path.join(categoryDir, slug)
+      if (!fs.statSync(providerDir).isDirectory()) continue
+
+      // Read provider.json — skip provider if absent
+      const providerJsonPath = path.join(providerDir, "provider.json")
+      if (!fs.existsSync(providerJsonPath)) continue
+
+      let providerMeta
+      try {
+        providerMeta = JSON.parse(fs.readFileSync(providerJsonPath, "utf8"))
+      } catch (err) {
+        console.warn(`Skipping ${slug}: could not parse provider.json — ${err.message}`)
+        continue
+      }
+
+      // Discover capabilities: subdirectories that contain a schema.json
+      const capabilities = []
+      let entries
+      try {
+        entries = fs.readdirSync(providerDir)
+      } catch {
+        entries = []
+      }
+
+      for (const entry of entries) {
+        const capDir = path.join(providerDir, entry)
+        if (!fs.statSync(capDir).isDirectory()) continue
+        const schemaPath = path.join(capDir, "schema.json")
+        if (!fs.existsSync(schemaPath)) continue
+
+        let schema
+        try {
+          schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"))
+        } catch {
+          continue
+        }
+
+        // Only include visible statuses (exclude draft, deprecated, archived)
+        if (VISIBLE_STATUSES.has(schema.status)) {
+          capabilities.push({ status: schema.status })
+        }
+      }
+
+      providers.push({
+        name: providerMeta.name,
+        category: providerMeta.category,
+        country_code: providerMeta.country_code || [],
+        capabilities,
+      })
+    }
+  }
+
+  return providers
+}
+
+// ─── Status computation ───────────────────────────────────────────────────────
+
+/**
+ * Compute the display status for a provider based on its capabilities.
+ * @param {Capability[]} capabilities
+ * @returns {string}
+ */
+function computeStatus(capabilities) {
+  if (capabilities.length === 0) return "🗓 Planifié"
+
+  const verifiedCount = capabilities.filter((c) => c.status === "verified").length
+  const readyCount = capabilities.length - verifiedCount
+
+  if (verifiedCount === capabilities.length) return "✅ AI Ready"
+  if (verifiedCount > 0) return `${verifiedCount} verified · ${readyCount} ready`
+  return "📋 Ready"
+}
+
+// ─── Table generation ─────────────────────────────────────────────────────────
+
+/**
+ * Sort providers: all_verified first, then by verified_count desc, then alphabetically.
+ * @param {ProviderData[]} providers
+ * @returns {ProviderData[]}
+ */
+function sortProviders(providers) {
+  return [...providers].sort((a, b) => {
+    const aVerified = a.capabilities.filter((c) => c.status === "verified").length
+    const bVerified = b.capabilities.filter((c) => c.status === "verified").length
+    const aAllVerified = a.capabilities.length > 0 && aVerified === a.capabilities.length
+    const bAllVerified = b.capabilities.length > 0 && bVerified === b.capabilities.length
+
+    if (aAllVerified !== bAllVerified) return aAllVerified ? -1 : 1
+    if (bVerified !== aVerified) return bVerified - aVerified
+    return a.name.localeCompare(b.name)
+  })
+}
+
+/**
+ * Build the Markdown providers table.
+ * @param {ProviderData[]} providers
+ * @returns {string}
+ */
+function buildTable(providers) {
+  const header = "| Provider | Catégorie | Pays | Capabilities | Statut |"
+  const sep = "|----------|-----------|------|-------------|--------|"
+
+  const rows = providers.map((p) => {
+    const flags = buildFlags(p.country_code)
+    const capCount = p.capabilities.length > 0 ? String(p.capabilities.length) : "—"
+    const status = computeStatus(p.capabilities)
+    return `| ${p.name} | ${p.category} | ${flags} | ${capCount} | ${status} |`
+  })
+
+  return [header, sep, ...rows].join("\n")
+}
+
+// ─── README injection ─────────────────────────────────────────────────────────
+
+/**
+ * Inject the generated table into README.md between the HTML comment markers.
+ * Idempotent: running twice produces the same result.
+ * @param {string} table
+ */
+function injectIntoReadme(table) {
+  let content
+  try {
+    content = fs.readFileSync(README_PATH, "utf8")
+  } catch (err) {
+    console.error(`Could not read README.md: ${err.message}`)
+    process.exit(1)
+  }
+
+  // Match everything between (and including) the two markers
+  const regex =
+    /<!-- tableau généré automatiquement[^>]*-->[\s\S]*?<!-- fin du tableau -->/
+
+  if (!regex.test(content)) {
+    console.error(
+      "ERROR: Markers not found in README.md.\n" +
+        `Expected opening marker: ${START_MARKER}\n` +
+        `Expected closing marker: ${END_MARKER}`
+    )
+    process.exit(1)
+  }
+
+  const replacement = `${START_MARKER}\n${table}\n${END_MARKER}`
+  const updated = content.replace(regex, replacement)
+
+  fs.writeFileSync(README_PATH, updated, "utf8")
+  console.log(`✓ README.md updated (${providers.length} providers)`)
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+const providers = discoverProviders()
+const sorted = sortProviders(providers)
+const table = buildTable(sorted)
+injectIntoReadme(table)

--- a/specs/payment/wave/provider.json
+++ b/specs/payment/wave/provider.json
@@ -16,7 +16,7 @@
     "CD"
   ],
   "website": "https://www.wave.com",
-  "docs_url": "https://docs.wave.com",
+  "docs_url": "https://docs.wave.com/business",
   "docs_public": true,
   "sandbox": false,
   "description": "Wave is a mobile money operator active in 11 African countries offering checkout sessions for e-commerce payments and batch payouts via a REST API.",


### PR DESCRIPTION
## Summary
- Corrects `docs_url` in `specs/payment/wave/provider.json` from `https://docs.wave.com` (broken) to `https://docs.wave.com/business` (correct)

## Test plan
- [ ] Verify `https://docs.wave.com/business` is accessible