### PR TITLE
chore(ci): dispatch specs-updated to afrotools/core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,14 @@ jobs:
       - name: Validate all specs (push to main)
         if: github.event_name == 'push'
         run: npm run validate
-      - name: Trigger MCP redeploy
+      - name: Trigger downstream redeploys
         if: github.event_name == 'push' && success()
         run: |
-          gh api repos/afrotools/mcp/dispatches \
-            --method POST --field event_type=specs-updated
+          for repo in afrotools/mcp afrotools/core; do
+            echo "Dispatching specs-updated to $repo..."
+            gh api repos/$repo/dispatches \
+              --method POST --field event_type=specs-updated
+          done
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
 


### PR DESCRIPTION
## Summary

`afrotools/core` already listens for `repository_dispatch[specs-updated]` in [`deploy.yml:10-11`](https://github.com/afrotools/core/blob/main/.github/workflows/deploy.yml), but until now only `afrotools/mcp` received the event from this workflow. Spec changes were not auto-propagated to https://afro.tools.

This PR loops the dispatch over both downstream repos. Adding a third consumer later is a one-line change.

## Context

This pairs with afrotools/core#9 — that PR moves the registry generation to build time, so `afrotools/core` now needs to be rebuilt when specs change. This wiring closes that loop.

## Test plan

- [ ] After merge, push a small spec change to main → confirm `afrotools/mcp` and `afrotools/core` workflows both trigger via `repository_dispatch`
- [ ] Confirm `https://afro.tools/providers` reflects the new spec without manual rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)