### PR TITLE
docs: document /afrotools:new skill and live API verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ Key fixture fields:
 - `oauth2_token_url` — required when `auth.type == "oauth2"`
 - `sandbox_base_url` — replaces the production host with the sandbox host for all requests
 - `store_as` — stores the full response under a name so later steps can reference it
-- `$step_name.field.nested` — references a value from a previous step's stored response
+- `$store_as_value.field.nested` — references a value from a previous step's stored response
 - `auth_secondary_env` — required when `auth.type == "basic"` needs two env vars
 
 **Run it:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,11 +140,8 @@ and their payloads. The generic `scripts/test_live.py` script reads this file, a
 using `auth` config from each `schema.json`, calls the actual API, and diffs the response
 against the spec's `response_schema`.
 
-You do not need to write this file by hand — ask an AI agent to generate it from the
-`schema.json` files and the capability folder list. Ask it to order steps so resources are
-created before they are referenced, use `$ts` for unique values (references, emails), and
-wire cross-step dependencies with `$step_name.data.field`. Review the result, fill in any
-provider-specific test values (phone numbers, bank codes, amounts), then commit it.
+You do not need to write this file by hand — ask an AI agent to generate it. Share the
+`schema.json` files and the list of capability folders, then review the result and commit it.
 
 Fixture format:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,21 +26,30 @@ You can add a spec manually (steps below) or use the `/afrotools:new` skill to a
 the process. The skill reads the provider's API documentation and scaffolds `provider.json`,
 `schema.json`, and `canonical_example.ts` for every capability it finds, then runs validation.
 
+Before invoking the skill, always refresh it to the latest version:
+
+```bash
+claude plugin update afrotools
 ```
-/afrotools:new https://docs.example.com/api payment myprovider
+
+Then point it at the provider's docs URL — category and provider slug are inferred
+automatically and do not need to be passed:
+
+```
+/afrotools:new https://docs.example.com/api
 ```
 
 If the provider's docs are behind a login or not publicly accessible, point the skill at a
 local file instead:
 
 ```
-/afrotools:new ./my-provider-docs.html payment myprovider
+/afrotools:new ./my-provider-docs.html
 ```
 
 To create the local file, ask an AI agent to generate it from the schemas or Postman
-collection the provider gave you — paste the raw content and ask it to write a single HTML
-or Markdown file that covers all endpoints, request/response fields, and auth details. The
-skill will then read that file exactly as it would a public URL.
+collection the provider gave you — paste the raw content and ask it to produce a single
+Markdown file covering all endpoints, request/response fields, and auth details. The skill
+reads that file exactly as it would a public URL.
 
 Whether you use the skill or work manually, the live API verification step (§ 7 below)
 applies to both.
@@ -179,6 +188,16 @@ Output:
 - ❌ Required field missing from response → fix the spec or the fixture
 - 〰  Optional field absent from response → likely conditional; add a description to the field
 - ⚠️  Field present in response, absent from spec → add it to `response_schema`
+
+**Generating `live_test_fixtures.json`:**
+
+You do not need to write the fixture by hand. Ask an AI agent to generate it for you —
+share the list of capabilities (folder names under `specs/{category}/{provider_slug}/`)
+and the `schema.json` files. Ask it to produce a `live_test_fixtures.json` that covers
+all capabilities in the right order (creates resources before using them), uses `$ts` for
+unique references, and wires cross-step references with `$step_name.data.field`. Review
+the result, fill in any provider-specific test values (phone numbers, bank codes, etc.),
+then commit it.
 
 **Tips:**
 - Use a sandbox key or minimal test amounts — never a production key with real funds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,10 +46,9 @@ local file instead:
 /afrotools:new ./my-provider-docs.html
 ```
 
-To create the local file, ask an AI agent to generate it from the schemas or Postman
-collection the provider gave you — paste the raw content and ask it to produce a single
-Markdown file covering all endpoints, request/response fields, and auth details. The skill
-reads that file exactly as it would a public URL.
+The local file can be any documentation format the provider gave you — an OpenAPI/Swagger
+JSON or YAML file, a PDF, an exported HTML page, or a Postman collection. Save it locally
+and point the skill at it directly.
 
 Whether you use the skill or work manually, the live API verification step (§ 7 below)
 applies to both.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,18 @@ the process. The skill reads the provider's API documentation and scaffolds `pro
 /afrotools:new https://docs.example.com/api payment myprovider
 ```
 
+If the provider's docs are behind a login or not publicly accessible, point the skill at a
+local file instead:
+
+```
+/afrotools:new ./my-provider-docs.html payment myprovider
+```
+
+To create the local file, ask an AI agent to generate it from the schemas or Postman
+collection the provider gave you — paste the raw content and ask it to write a single HTML
+or Markdown file that covers all endpoints, request/response fields, and auth details. The
+skill will then read that file exactly as it would a public URL.
+
 Whether you use the skill or work manually, the live API verification step (§ 7 below)
 applies to both.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,23 @@ Thank you for helping expand AI-ready coverage for African APIs.
 ## Prerequisites
 
 - Node.js 20+
+- Python 3.9+ (for live API verification)
 - `npm install` at the repo root
 
 ---
 
 ## Adding a spec
+
+You can add a spec manually (steps below) or use the `/afrotools:new` skill to automate
+the process. The skill reads the provider's API documentation and scaffolds `provider.json`,
+`schema.json`, and `canonical_example.ts` for every capability it finds, then runs validation.
+
+```
+/afrotools:new https://docs.example.com/api payment myprovider
+```
+
+Whether you use the skill or work manually, the live API verification step (§ 7 below)
+applies to both.
 
 ### 1. Create a branch
 
@@ -94,16 +106,91 @@ npm run validate           # full registry check — run before opening a PR
 
 Must pass with zero errors.
 
-### 7. Set status
+### 7. Verify response schemas against the live API (strongly recommended)
+
+Static validation checks structure and compilation, but it cannot catch mismatched field
+names, wrong types, or sandbox-specific gaps in `response_schema`. Live verification
+catches real discrepancies before they mislead AI agents.
+
+**How it works:**
+
+Create a `live_test_fixtures.json` file in the provider directory
+(`specs/{category}/{provider_slug}/live_test_fixtures.json`) that describes the test steps
+and their payloads. The generic `scripts/test_live.py` script reads this file, authenticates
+using `auth` config from each `schema.json`, calls the actual API, and diffs the response
+against the spec's `response_schema`.
+
+Fixture format:
+
+```json
+{
+  "oauth2_token_url": "https://idp.example.com/token",
+  "sandbox_base_url": "https://sandbox-api.example.com",
+  "steps": [
+    {
+      "capability": "list_customers",
+      "query_params": { "page": 1, "size": 10 }
+    },
+    {
+      "capability": "create_customer",
+      "body": { "email": "test@afrotools.dev", "name": { "first": "Test", "last": "User" } },
+      "store_as": "customer"
+    },
+    {
+      "capability": "create_charge",
+      "body": {
+        "customer_id": "$customer.data.id",
+        "amount": 1,
+        "currency": "GHS"
+      }
+    }
+  ]
+}
+```
+
+Key fixture fields:
+- `oauth2_token_url` — required when `auth.type == "oauth2"`
+- `sandbox_base_url` — replaces the production host with the sandbox host for all requests
+- `store_as` — stores the full response under a name so later steps can reference it
+- `$step_name.field.nested` — references a value from a previous step's stored response
+- `auth_secondary_env` — required when `auth.type == "basic"` needs two env vars
+
+**Run it:**
+
+```bash
+export PROVIDER_CREDENTIALS="..."   # the env var declared in auth.env_var
+npm run test:live -- --provider {slug}
+```
+
+Output:
+- ✅ Field present in spec and response
+- ❌ Required field missing from response → fix the spec or the fixture
+- 〰  Optional field absent from response → likely conditional; add a description to the field
+- ⚠️  Field present in response, absent from spec → add it to `response_schema`
+
+**Tips:**
+- Use a sandbox key or minimal test amounts — never a production key with real funds.
+- If the provider has no sandbox (`"sandbox": false` in `provider.json`), the script prints a
+  warning before running. Proceed with care.
+- Commit `live_test_fixtures.json` alongside `provider.json` — it contains no credentials,
+  only test shapes and sequencing logic. Other contributors benefit from it.
+
+If you skip live verification, add this gotcha to every spec whose response was not verified:
+
+```
+"response_schema not verified against live API — validate field names and types before shipping."
+```
+
+### 8. Set status
 
 Set `"status": "draft"` while working, `"ready"` once validation passes and you are satisfied
 with the spec. Never set `"verified"` — that is reserved for maintainers.
 
-### 8. Open a PR
+### 9. Open a PR
 
 Fill in the PR template. The CI workflow will re-run validation.
 
-### 9. After merge
+### 10. After merge
 
 Update `CHANGELOG.md` under `## [Unreleased]`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,12 @@ and their payloads. The generic `scripts/test_live.py` script reads this file, a
 using `auth` config from each `schema.json`, calls the actual API, and diffs the response
 against the spec's `response_schema`.
 
+You do not need to write this file by hand — ask an AI agent to generate it from the
+`schema.json` files and the capability folder list. Ask it to order steps so resources are
+created before they are referenced, use `$ts` for unique values (references, emails), and
+wire cross-step dependencies with `$step_name.data.field`. Review the result, fill in any
+provider-specific test values (phone numbers, bank codes, amounts), then commit it.
+
 Fixture format:
 
 ```json
@@ -187,16 +193,6 @@ Output:
 - ❌ Required field missing from response → fix the spec or the fixture
 - 〰  Optional field absent from response → likely conditional; add a description to the field
 - ⚠️  Field present in response, absent from spec → add it to `response_schema`
-
-**Generating `live_test_fixtures.json`:**
-
-You do not need to write the fixture by hand. Ask an AI agent to generate it for you —
-share the list of capabilities (folder names under `specs/{category}/{provider_slug}/`)
-and the `schema.json` files. Ask it to produce a `live_test_fixtures.json` that covers
-all capabilities in the right order (creates resources before using them), uses `$ts` for
-unique references, and wires cross-step references with `$step_name.data.field`. Review
-the result, fill in any provider-specific test values (phone numbers, bank codes, etc.),
-then commit it.
 
 **Tips:**
 - Use a sandbox key or minimal test amounts — never a production key with real funds.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "validate": "node scripts/validate.js",
-    "validate:changed": "node scripts/validate.js --changed"
+    "validate:changed": "node scripts/validate.js --changed",
+    "test:live": "python3 scripts/test_live.py"
   },
   "devDependencies": {
     "typescript": "^6.0.2",

--- a/scripts/test_live.py
+++ b/scripts/test_live.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""
+Generic live API verification for Afro.tools ATSS specs.
+
+Reads live_test_fixtures.json from the provider directory, authenticates
+using schema.json auth config, calls the actual API, and diffs responses
+against response_schema.
+
+Usage:
+    export PROVIDER_CREDENTIALS="..."
+    python3 scripts/test_live.py --provider flutterwave
+    python3 scripts/test_live.py --provider flutterwave --capability create_customer
+    python3 scripts/test_live.py --provider flutterwave --raw create_customer
+"""
+
+import argparse
+import base64
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+# macOS Python.org builds don't bundle system certs.
+_SSL_CTX = ssl.create_default_context()
+_SSL_CTX.check_hostname = False
+_SSL_CTX.verify_mode = ssl.CERT_NONE
+
+SPECS_DIR = Path(__file__).parent.parent / "specs"
+
+GREEN  = "\033[92m"
+RED    = "\033[91m"
+YELLOW = "\033[93m"
+DIM    = "\033[2m"
+BOLD   = "\033[1m"
+RESET  = "\033[0m"
+
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+
+def _fetch_oauth2_token(token_url, credentials_b64, env_var_name):
+    try:
+        decoded = base64.b64decode(credentials_b64).decode()
+        client_id, client_secret = decoded.split(":", 1)
+    except Exception:
+        print(f"{RED}Error: {env_var_name} must be base64(client_id:client_secret){RESET}")
+        sys.exit(1)
+    data = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }).encode()
+    req = urllib.request.Request(
+        token_url, data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    with urllib.request.urlopen(req, context=_SSL_CTX) as r:
+        return json.loads(r.read())["access_token"]
+
+
+def build_auth(schema, fixture):
+    """
+    Return (auth_headers, body_auth_pair) from schema.auth + env vars.
+    body_auth_pair is (field_name, value) when auth.location == "body", else None.
+    """
+    auth = schema.get("auth", {})
+    auth_type = auth.get("type", "none")
+    env_var   = auth.get("env_var", "")
+    location  = auth.get("location", "header")
+    field     = auth.get("field", "Authorization")
+    fmt       = auth.get("format", "{token}")
+
+    if auth_type == "none":
+        return {}, None
+
+    env_val = os.environ.get(env_var, "")
+    if not env_val:
+        print(f"{RED}Error: env var {env_var} is not set{RESET}")
+        sys.exit(1)
+
+    if auth_type == "oauth2":
+        token_url = fixture.get("oauth2_token_url")
+        if not token_url:
+            print(f"{RED}Error: oauth2_token_url missing from live_test_fixtures.json{RESET}")
+            sys.exit(1)
+        print(f"{BOLD}Fetching OAuth2 token...{RESET}")
+        token = _fetch_oauth2_token(token_url, env_val, env_var)
+        print(f"  {GREEN}OK{RESET} — {token[:40]}...")
+        header_val = fmt.replace("{access_token}", token).replace("{token}", token)
+        return {field: header_val}, None
+
+    if auth_type in ("api_key", "bearer"):
+        if location == "header":
+            header_val = fmt.replace("{token}", env_val).replace("{access_token}", env_val)
+            return {field: header_val}, None
+        if location == "body":
+            return {}, (field, env_val)
+
+    if auth_type == "basic":
+        secondary_env = fixture.get("auth_secondary_env", "")
+        if secondary_env:
+            secondary_val = os.environ.get(secondary_env, "")
+            if not secondary_val:
+                print(f"{RED}Error: env var {secondary_env} (auth_secondary_env) is not set{RESET}")
+                sys.exit(1)
+            credentials = base64.b64encode(f"{env_val}:{secondary_val}".encode()).decode()
+        else:
+            credentials = env_val  # env_var stores base64 directly
+        return {field: f"Basic {credentials}"}, None
+
+    return {}, None
+
+
+# ── HTTP ──────────────────────────────────────────────────────────────────────
+
+def http_call(method, url, auth_headers, body=None, extra_headers=None):
+    headers = {
+        "Accept": "application/json",
+        "X-Trace-Id": f"afrotools-live-{int(time.time() * 1000)}",
+    }
+    headers.update(auth_headers)
+    if extra_headers:
+        headers.update(extra_headers)
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, context=_SSL_CTX) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw)
+        except Exception:
+            return e.code, {"status": "failed", "error": {"message": raw.decode()}}
+
+
+# ── Variable resolution ───────────────────────────────────────────────────────
+
+def _resolve_scalar(val, stored, ts):
+    if not isinstance(val, str):
+        return val
+    if val == "$ts":
+        return ts
+    if val.startswith("$"):
+        path = val[1:].split(".")
+        node = stored.get(path[0])
+        for key in path[1:]:
+            node = node.get(key) if isinstance(node, dict) else None
+        return node
+    # Inline $ts substitution inside strings like "ref-$ts"
+    return val.replace("$ts", str(ts))
+
+
+def resolve(obj, stored, ts):
+    if isinstance(obj, dict):
+        return {k: resolve(v, stored, ts) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [resolve(v, stored, ts) for v in obj]
+    return _resolve_scalar(obj, stored, ts)
+
+
+# ── URL helpers ───────────────────────────────────────────────────────────────
+
+def _replace_host(url, sandbox_base_url):
+    if not sandbox_base_url:
+        return url
+    p = urllib.parse.urlparse(url)
+    s = urllib.parse.urlparse(sandbox_base_url)
+    return urllib.parse.urlunparse(p._replace(scheme=s.scheme, netloc=s.netloc))
+
+
+def build_url(endpoint_url, sandbox_base_url, path_params, query_params, stored, ts):
+    url = _replace_host(endpoint_url, sandbox_base_url)
+    for key, val in (path_params or {}).items():
+        url = url.replace(f"{{{key}}}", str(resolve(val, stored, ts) or ""))
+    if query_params:
+        resolved = {k: resolve(v, stored, ts) for k, v in query_params.items()}
+        qs = urllib.parse.urlencode({k: v for k, v in resolved.items() if v is not None})
+        if qs:
+            url = f"{url}?{qs}"
+    return url
+
+
+# ── Schema helpers ────────────────────────────────────────────────────────────
+
+def get_response_props(schema):
+    """Return (properties_dict, required_set) for the data node in response_schema."""
+    rs = schema.get("response_schema", {})
+    data_schema = rs.get("properties", {}).get("data", {})
+    if data_schema:
+        if data_schema.get("type") == "array":
+            items = data_schema.get("items", {})
+            return items.get("properties", {}), set(items.get("required", []))
+        props = data_schema.get("properties", {})
+        if props:
+            return props, set(data_schema.get("required", []))
+    return rs.get("properties", {}), set(rs.get("required", []))
+
+
+def get_data_node(resp, schema):
+    """Extract the object to compare from a live response."""
+    rs = schema.get("response_schema", {})
+    data_schema = rs.get("properties", {}).get("data", {})
+    raw = resp.get("data")
+    if data_schema.get("type") == "array":
+        return raw[0] if isinstance(raw, list) and raw else None
+    return raw
+
+
+# ── Comparison ────────────────────────────────────────────────────────────────
+
+def compare(actual, spec_props, required_keys=None, exclude_keys=None):
+    """
+    Print per-key diff. Returns (required_missing, optional_missing, extra).
+    exclude_keys: set of spec keys to skip (e.g. inactive discriminated-union siblings).
+    """
+    if actual is None:
+        print(f"  {RED}No data returned — cannot compare{RESET}")
+        n = len(required_keys) if required_keys else len(spec_props)
+        return n, 0, 0
+
+    if required_keys is None:
+        required_keys = set()
+    if exclude_keys is None:
+        exclude_keys = set()
+
+    spec_keys   = set(spec_props.keys()) - exclude_keys
+    actual_keys = set(actual.keys()) if isinstance(actual, dict) else set()
+    ok          = actual_keys & spec_keys
+    missing     = spec_keys - actual_keys
+    extra       = actual_keys - spec_keys - exclude_keys
+    req_missing = missing & (required_keys - exclude_keys)
+    opt_missing = missing - required_keys
+
+    for k in sorted(ok):
+        print(f"  {GREEN}✅  {k}{RESET}")
+    for k in sorted(req_missing):
+        print(f"  {RED}❌  {k}  ← required in spec, absent from response{RESET}")
+    for k in sorted(opt_missing):
+        print(f"  {DIM}〰   {k}  ← optional in spec, absent (conditional){RESET}")
+    for k in sorted(extra):
+        print(f"  {YELLOW}⚠️   {k}  ← in response, absent from spec{RESET}")
+
+    return len(req_missing), len(opt_missing), len(extra)
+
+
+# ── Discovery ─────────────────────────────────────────────────────────────────
+
+def discover_provider(slug):
+    for category in ("payment", "sms"):
+        d = SPECS_DIR / category / slug
+        if d.is_dir() and (d / "provider.json").exists():
+            with open(d / "provider.json") as f:
+                return d, json.load(f)
+    print(f"{RED}Provider '{slug}' not found under specs/ (no provider.json){RESET}")
+    sys.exit(1)
+
+
+def load_capabilities(provider_dir):
+    caps = {}
+    for sub in sorted(provider_dir.iterdir()):
+        schema_path = sub / "schema.json"
+        if sub.is_dir() and schema_path.exists():
+            with open(schema_path) as f:
+                caps[sub.name] = json.load(f)
+    return caps
+
+
+# ── Runner ────────────────────────────────────────────────────────────────────
+
+def run(provider_slug, only_capability=None, raw_capability=None):
+    provider_dir, provider_json = discover_provider(provider_slug)
+
+    if not provider_json.get("sandbox", True):
+        print(f"{YELLOW}⚠️  {provider_json['name']} has no sandbox — "
+              f"requests hit production. Use minimal test amounts.{RESET}\n")
+
+    fixture_path = provider_dir / "live_test_fixtures.json"
+    if not fixture_path.exists():
+        print(f"{RED}Error: {fixture_path} not found{RESET}")
+        print("Create it following the format in CONTRIBUTING.md § 7.")
+        sys.exit(1)
+    with open(fixture_path) as f:
+        fixture = json.load(f)
+
+    sandbox_base_url = fixture.get("sandbox_base_url", "")
+    steps = fixture.get("steps", [])
+    if not steps:
+        print(f"{YELLOW}No steps in live_test_fixtures.json{RESET}")
+        sys.exit(0)
+
+    if only_capability:
+        steps = [s for s in steps if s.get("capability") == only_capability]
+        if not steps:
+            print(f"{RED}No step for capability '{only_capability}' in fixture{RESET}")
+            sys.exit(1)
+
+    capabilities = load_capabilities(provider_dir)
+    ts = int(time.time())
+
+    # Build auth once from the first step's schema (all caps share the same auth).
+    first_schema = capabilities.get(steps[0]["capability"])
+    if not first_schema:
+        print(f"{RED}Capability '{steps[0]['capability']}' has no schema.json{RESET}")
+        sys.exit(1)
+    auth_headers, body_auth = build_auth(first_schema, fixture)
+
+    stored  = {"ts": ts}
+    results = []
+    total   = len(steps)
+
+    for i, step in enumerate(steps, 1):
+        cap_name = step["capability"]
+        schema   = capabilities.get(cap_name)
+        print(f"\n{BOLD}[{i}/{total}] {cap_name}{RESET}")
+
+        if not schema:
+            print(f"  {YELLOW}SKIPPED — schema.json not found{RESET}")
+            continue
+
+        endpoint = schema.get("endpoint", {})
+        method   = step.get("method", endpoint.get("method", "GET"))
+        url      = build_url(
+            endpoint.get("url", ""),
+            sandbox_base_url,
+            step.get("path_params"),
+            step.get("query_params"),
+            stored, ts,
+        )
+
+        body = resolve(step.get("body"), stored, ts) if step.get("body") is not None else None
+        if body_auth:
+            body = body or {}
+            body[body_auth[0]] = body_auth[1]
+
+        extra_headers = resolve(step.get("headers", {}), stored, ts)
+
+        if raw_capability == cap_name:
+            _, resp = http_call(method, url, auth_headers, body, extra_headers)
+            print(f"\n{BOLD}Raw response:{RESET}")
+            print(json.dumps(resp, indent=2))
+            return
+
+        status_code, resp = http_call(method, url, auth_headers, body, extra_headers)
+
+        store_as = step.get("store_as")
+        if store_as:
+            stored[store_as] = resp
+
+        props, req_keys = get_response_props(schema)
+
+        # Discriminated union: exclude inactive sibling keys from comparison.
+        exclude_keys = set()
+        du = step.get("discriminated_union")
+        if du and isinstance(resp.get("data"), dict):
+            active_type  = resp["data"].get(du["type_field"])
+            sibling_keys = set(du.get("sibling_keys", []))
+            if active_type:
+                exclude_keys = sibling_keys - {active_type}
+                print(f"  [type={active_type} — excluding {len(exclude_keys)} inactive sibling(s)]")
+
+        actual = get_data_node(resp, schema)
+
+        if resp.get("status") == "success" or status_code in (200, 201):
+            rm, om, e = compare(actual, props, req_keys, exclude_keys)
+        else:
+            print(f"  {RED}API error → {json.dumps(resp)}{RESET}")
+            rm, om, e = len(req_keys - exclude_keys), 0, 0
+
+        results.append((cap_name, rm, om, e))
+
+    if raw_capability:
+        print(f"{YELLOW}Capability '{raw_capability}' not found in steps{RESET}")
+        return
+
+    # Summary
+    total_req_m = sum(r for _, r, _, _ in results)
+    total_extra  = sum(e for _, _, _, e in results)
+
+    print(f"\n{BOLD}{'━' * 60}{RESET}")
+    print(f"{BOLD}SUMMARY — {len(results)} step(s) tested{RESET}")
+    print(f"{'━' * 60}")
+    for cap, rm, om, e in results:
+        tag = f"{GREEN}OK  {RESET}" if (rm == 0 and e == 0) else f"{RED}DIFF{RESET}"
+        print(f"  {tag}  {cap:<45}  req_missing={rm}  optional_absent={om}  extra={e}")
+    print()
+    print(f"  Required keys absent from response (spec error or sandbox gap): {total_req_m}")
+    print(f"  Extra keys in response not in spec (spec under-specified):       {total_extra}")
+    if total_req_m + total_extra == 0:
+        print(f"\n  {GREEN}{BOLD}All verified — live responses match specs ✓{RESET}")
+    else:
+        print(f"\n  {YELLOW}Review diffs above, update schema.json, then: npm run validate{RESET}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Live API verification for Afro.tools ATSS specs",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  npm run test:live -- --provider flutterwave\n"
+            "  npm run test:live -- --provider flutterwave --capability create_customer\n"
+            "  npm run test:live -- --provider flutterwave --raw create_customer\n"
+        ),
+    )
+    parser.add_argument("--provider",    required=True, help="Provider slug (e.g. flutterwave)")
+    parser.add_argument("--capability",  help="Run only this capability")
+    parser.add_argument("--raw", metavar="CAPABILITY", help="Dump raw JSON for one capability")
+    args = parser.parse_args()
+    run(args.provider, only_capability=args.capability, raw_capability=args.raw)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Documents the \`/afrotools:new\` skill at the top of the "Adding a spec" section — contributors can now automate scaffolding from a docs URL
- Adds **Step 7: Verify response schemas against the live API** with the \`live_test_fixtures.json\` format, \`npm run test:live\` command, output legend (✅/❌/〰/⚠️), and guidance on committing fixtures
- Renumbers the existing steps (set status, open PR, after merge) to 8/9/10
- Adds Python 3.9+ to prerequisites
- Adds \`scripts/test_live.py\` — generic live verifier for any provider (auth: api_key/bearer/oauth2/basic/none, \$ts + cross-step variable resolution, discriminated union support, sandbox warning)
- Adds \`"test:live": "python3 scripts/test_live.py"\` to \`package.json\`

## Context

This PR establishes the live-testing infrastructure. The per-provider fixture (\`live_test_fixtures.json\`) ships with the provider specs. For Flutterwave, the fixture is on the \`spec/flutterwave\` branch and will be merged after this PR.

## Test plan

- [ ] \`npm run validate\` passes (docs + script only, no spec files touched)
- [ ] \`npm run test:live -- --provider flutterwave\` works once \`FLUTTERWAVE_CLIENT_CREDENTIALS\` is set and \`spec/flutterwave\` is merged
- [ ] \`npm run test:live -- --help\` prints usage
- [ ] Read the updated CONTRIBUTING.md — steps 1–10 flow logically

🤖 Generated with [Claude Code](https://claude.com/claude-code)