### PR TITLE
feat(kadevpay): add KadevPay specs + ATSS sdk capability_type

### DIFF
--- a/ATSS.md
+++ b/ATSS.md
@@ -100,7 +100,7 @@ One `provider.json` per provider directory. Carries provider-level metadata migr
 | spec_version | string | Always "1.0" |
 | provider_api_version | string | YYYY-MM-DD if provider has no version string |
 | capability | string | snake_case — matches the directory name |
-| capability_type | enum | `synchronous`, `asynchronous`, or `webhook` |
+| capability_type | enum | `synchronous`, `asynchronous`, `webhook`, or `sdk` |
 | status | enum | `draft`, `ready`, `verified`, `deprecated`, `archived` |
 | currency | string[] | ISO 4217 codes |
 | sandbox | boolean | true if provider has a sandbox environment |
@@ -121,6 +121,7 @@ One `provider.json` per provider directory. Carries provider-level metadata migr
 - `synchronous` — request/response, result available immediately in the HTTP response
 - `asynchronous` — provider processes in background, poll a separate endpoint for result
 - `webhook` — provider sends an HTTP POST to your endpoint when an event occurs
+- `sdk` — capability delivered through a client-side SDK script (no direct HTTP endpoint). `endpoint.url` holds the CDN URL of the SDK script; `endpoint.method` is `null`. The `canonical_example.ts` exports a server-side configuration helper; the actual SDK invocation is shown in the usage comment block. Auth credential goes in `auth.location: "sdk_param"` (the SDK's config object).
 
 ---
 
@@ -268,3 +269,4 @@ Gotchas must be: specific, actionable, based on real integration experience.
 | Wave | payment | wave | SN, CI, ML, GN, UG, BF, GM, NE, CM, SL, CD | create_checkout_session, create_payout_batch, expire_checkout, get_balance, get_payout, get_transactions, refund_checkout, search_checkouts, send_payout, verify_payment, verify_recipient, webhook_payment_completed | ready (12/12) |
 | NimbaSMS | sms | nimbasms | GN | create_contact, get_balance, get_message, list_contacts, list_groups, list_messages, list_sendernames, send_message, send_verification, verify_code, webhook_sms_status | ready (11/11) |
 | Bictorys | payment | bictorys | — | — | planned |
+| KadevPay | payment | kadevpay | CI | create_checkout_session, verify_payment, webhook_payment_success | draft (0/3) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,3 +140,4 @@ afrotools/examples uses specs as the reference for its integration layer.
 - Never add MCP server code to this repo
 - Never put real API keys or secrets in `plugin/.mcp.json`
 - Never push directly to main — always use a branch and PR
+- Never apply `encodeURIComponent` to path parameters in `canonical_example.ts` unless the provider documentation explicitly requires it — API references (transaction IDs, payment link references, etc.) use safe characters by design; encoding them silently breaks the request

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,12 +84,12 @@ afrotools/afrotools/
 ## Spec status lifecycle
 
 ```
-draft → compliant → verified → deprecated → archived
+draft → ready → verified → deprecated → archived
 ```
 
 - `draft` — work in progress, not yet validated
-- `compliant` — schema valid, canonical_example compiles, gotchas present. Visible in MCP.
-- `verified` — compliant + working example in afrotools/examples. Earns "AI Ready" badge.
+- `ready` — schema valid, canonical_example compiles, gotchas present. Visible in MCP.
+- `verified` — ready + working example in afrotools/examples. Earns "AI Ready" badge.
 - Only maintainers can set `verified`, `deprecated`, or `archived`.
 
 ## Running validation
@@ -127,7 +127,7 @@ afrotools/examples uses specs as the reference for its integration layer.
 3. Add `schema.json` following `schema.template.json`
 4. Add `canonical_example.ts` following ATSS rules in `specs/CLAUDE.md`
 5. Run `npm run validate` — must pass with zero errors
-6. Set `status` to `draft` or `compliant` in `schema.json`
+6. Set `status` to `draft` or `ready` in `schema.json`
 7. Open a PR with the template filled in
 8. After merge: update `CHANGELOG.md`
 

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -42,7 +42,7 @@ const REQUIRED_FIELDS = [
   "gotchas",
 ];
 
-const VALID_CAPABILITY_TYPES = ["synchronous", "asynchronous", "webhook"];
+const VALID_CAPABILITY_TYPES = ["synchronous", "asynchronous", "webhook", "sdk"];
 const VALID_STATUSES = ["draft", "ready", "verified", "deprecated", "archived"];
 
 // ---------------------------------------------------------------------------

--- a/specs/payment/djomy/get_payment_link/canonical_example.ts
+++ b/specs/payment/djomy/get_payment_link/canonical_example.ts
@@ -84,7 +84,7 @@ export async function getPaymentLink(
   const accessToken = await getAccessToken();
 
   const response = await fetch(
-    `${DJOMY_BASE_URL}/v1/links/${encodeURIComponent(paymentLinkReference)}`,
+    `${DJOMY_BASE_URL}/v1/links/${paymentLinkReference}`,
     {
       method: "GET",
       headers: {

--- a/specs/payment/djomy/get_payment_link/schema.json
+++ b/specs/payment/djomy/get_payment_link/schema.json
@@ -194,6 +194,7 @@
     "A 404 is returned if the reference does not exist or belongs to a different merchant account. Check that you are using the correct credentials and the correct reference.",
     "For UNIQUE links, data.status becomes REVOKED after one successful payment — not PAID. PAID is only set in specific conditions. Use data.numberOfUsage > 0 as the reliable indicator that a UNIQUE link has been used.",
     "Auth requires two steps: (1) compute HMAC-SHA256(clientId, clientSecret) as hex, (2) call POST /v1/auth with header X-API-KEY: clientId:hexSignature to get a Bearer token.",
-    "The base URL in this spec is the sandbox (https://sandbox-api.djomy.africa). Replace with the production URL for live payments."
+    "The base URL in this spec is the sandbox (https://sandbox-api.djomy.africa). Replace with the production URL for live payments.",
+    "Pass the reference directly as a path segment — do not URL-encode it. The paymentLinkReference format contains only safe characters."
   ]
 }

--- a/specs/payment/kadevpay/create_checkout_session/canonical_example.ts
+++ b/specs/payment/kadevpay/create_checkout_session/canonical_example.ts
@@ -1,0 +1,60 @@
+/**
+ * @provider KadevPay
+ * @capability create_checkout_session
+ * @atss 1.0
+ * @capability_type sdk
+ */
+
+const KADEVPAY_PUBLIC_KEY = process.env.KADEVPAY_PUBLIC_KEY;
+if (!KADEVPAY_PUBLIC_KEY) throw new Error("Missing env: KADEVPAY_PUBLIC_KEY");
+
+interface CheckoutSessionInput {
+  amount: number;
+  email: string;
+  method: "momo" | "card";
+  name?: string;
+  phone?: string;
+  callback_url?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface CheckoutSessionConfig extends CheckoutSessionInput {
+  public_key: string;
+}
+
+export function buildCheckoutConfig(input: CheckoutSessionInput): CheckoutSessionConfig {
+  return {
+    ...input,
+    public_key: KADEVPAY_PUBLIC_KEY as string,
+  };
+}
+
+/*
+Usage example:
+
+// 1. Include the KadevPay SDK in your HTML:
+// <script src="https://pay.kadev.ci/js/v1/kadev-pay.js"></script>
+
+// 2. Build the config (server-side, pass it to the frontend):
+const config = buildCheckoutConfig({
+  amount: 5000,                              // in XOF (FCFA)
+  email: "client@email.com",
+  method: "momo",                            // "momo" or "card"
+  name: "Jean Dupont",
+  callback_url: "https://myapp.com/payment/callback",
+  metadata: { order_id: "CMD-9982" },
+});
+
+// 3. On the client, invoke the SDK:
+// KadevPay.checkout({
+//   ...config,
+//   onSuccess: (reference: string) => {
+//     // Save the reference and verify server-side before fulfilling the order
+//     fetch("/api/verify-payment", {
+//       method: "POST",
+//       body: JSON.stringify({ reference }),
+//     });
+//   },
+//   onClose: () => { console.log("Checkout closed by user"); },
+// });
+*/

--- a/specs/payment/kadevpay/create_checkout_session/schema.json
+++ b/specs/payment/kadevpay/create_checkout_session/schema.json
@@ -1,0 +1,61 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "v1",
+  "capability": "create_checkout_session",
+  "capability_type": "sdk",
+  "status": "draft",
+  "currency": ["XOF"],
+  "auth": {
+    "type": "api_key",
+    "location": "sdk_param",
+    "field": "public_key",
+    "format": "{token}",
+    "env_var": "KADEVPAY_PUBLIC_KEY"
+  },
+  "endpoint": {
+    "method": null,
+    "url": "https://pay.kadev.ci/js/v1/kadev-pay.js"
+  },
+  "example_prompt": "Initialize a KadevPay checkout session and redirect the customer to complete a mobile money or card payment.",
+  "input_schema": {
+    "type": "object",
+    "required": ["amount", "email", "method"],
+    "properties": {
+      "amount": {
+        "type": "number",
+        "description": "Amount in XOF (FCFA), e.g. 5000"
+      },
+      "email": {
+        "type": "string",
+        "format": "email"
+      },
+      "method": {
+        "type": "string",
+        "enum": ["momo", "card"]
+      },
+      "name": {
+        "type": "string"
+      },
+      "phone": {
+        "type": "string"
+      },
+      "callback_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL to redirect after payment"
+      },
+      "metadata": {
+        "type": "object"
+      }
+    }
+  },
+  "response_schema": {},
+  "error_schema": {},
+  "gotchas": [
+    "Use the PUBLIC key (kdvp_*) in KadevPay.checkout(), not the secret key — the secret key is only for server-side verify_payment calls.",
+    "amount is a number in XOF (FCFA), not a string — e.g. 5000 for 5000 FCFA.",
+    "Save the transaction reference returned via the onSuccess callback — you need it to call verify_payment before fulfilling the order.",
+    "For method: 'card', KadevPay processes payments via Paystack internally — no additional Paystack integration is needed.",
+    "Always call verify_payment server-side after checkout — the onSuccess callback can be spoofed."
+  ]
+}

--- a/specs/payment/kadevpay/create_checkout_session/schema.json
+++ b/specs/payment/kadevpay/create_checkout_session/schema.json
@@ -3,7 +3,7 @@
   "provider_api_version": "v1",
   "capability": "create_checkout_session",
   "capability_type": "sdk",
-  "status": "draft",
+  "status": "ready",
   "currency": ["XOF"],
   "auth": {
     "type": "api_key",

--- a/specs/payment/kadevpay/provider.json
+++ b/specs/payment/kadevpay/provider.json
@@ -1,0 +1,12 @@
+{
+  "slug": "kadevpay",
+  "name": "KadevPay",
+  "category": "payment",
+  "country_code": ["CI"],
+  "website": "https://pay.kadev.ci",
+  "docs_url": "https://pay.kadev.ci/developer-documentation",
+  "docs_public": true,
+  "sandbox": true,
+  "description": "KadevPay is an Ivorian payment gateway supporting mobile money (Orange Money, MTN MoMo) and card payments via a client-side JavaScript SDK.",
+  "example_prompt": "Add KadevPay checkout to my app to accept mobile money and card payments in Côte d'Ivoire."
+}

--- a/specs/payment/kadevpay/verify_payment/canonical_example.ts
+++ b/specs/payment/kadevpay/verify_payment/canonical_example.ts
@@ -34,7 +34,7 @@ interface KadevPayError {
 
 export async function verifyPayment(reference: string): Promise<VerifyPaymentResponse> {
   const response = await fetch(
-    `https://pay.kadev.ci/api/v1/transactions/verify/${encodeURIComponent(reference)}`,
+    `https://pay.kadev.ci/api/v1/transactions/verify/${reference}`,
     {
       method: "GET",
       headers: {

--- a/specs/payment/kadevpay/verify_payment/canonical_example.ts
+++ b/specs/payment/kadevpay/verify_payment/canonical_example.ts
@@ -1,0 +1,69 @@
+/**
+ * @provider KadevPay
+ * @capability verify_payment
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const KADEVPAY_SECRET_KEY = process.env.KADEVPAY_SECRET_KEY;
+if (!KADEVPAY_SECRET_KEY) throw new Error("Missing env: KADEVPAY_SECRET_KEY");
+
+interface VerifyPaymentCustomer {
+  full_name?: string;
+  email?: string;
+}
+
+interface VerifyPaymentData {
+  reference: string;
+  status: "paid" | "pending" | "failed";
+  amount: number;
+  currency: "XOF";
+  customer?: VerifyPaymentCustomer;
+  paid_at?: string;
+}
+
+interface VerifyPaymentResponse {
+  status: string;
+  mode?: "test" | "live";
+  data: VerifyPaymentData;
+}
+
+interface KadevPayError {
+  message: string;
+}
+
+export async function verifyPayment(reference: string): Promise<VerifyPaymentResponse> {
+  const response = await fetch(
+    `https://pay.kadev.ci/api/v1/transactions/verify/${encodeURIComponent(reference)}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${KADEVPAY_SECRET_KEY}`,
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error: KadevPayError = await response.json();
+    throw new Error(`KadevPay verify error ${response.status}: ${error.message}`);
+  }
+
+  return response.json() as Promise<VerifyPaymentResponse>;
+}
+
+/*
+Usage example:
+
+// After receiving the reference from the checkout onSuccess callback or callback_url redirect:
+const result = await verifyPayment("KDV-1775413916000");
+
+if (result.data.status === "paid") {
+  // Safe to fulfill the order
+  console.log("Payment confirmed:", result.data.amount, result.data.currency);
+  console.log("Customer:", result.data.customer?.full_name);
+} else {
+  // Do not fulfill — payment is still pending or failed
+  console.log("Payment not completed:", result.data.status);
+}
+*/

--- a/specs/payment/kadevpay/verify_payment/canonical_example.ts
+++ b/specs/payment/kadevpay/verify_payment/canonical_example.ts
@@ -58,12 +58,12 @@ Usage example:
 // After receiving the reference from the checkout onSuccess callback or callback_url redirect:
 const result = await verifyPayment("KDV-1775413916000");
 
-if (result.data.status === "paid") {
+if (result.status === "success" && result.data.status === "paid") {
   // Safe to fulfill the order
   console.log("Payment confirmed:", result.data.amount, result.data.currency);
   console.log("Customer:", result.data.customer?.full_name);
 } else {
-  // Do not fulfill — payment is still pending or failed
-  console.log("Payment not completed:", result.data.status);
+  // Do not fulfill — payment is still pending, failed, or the reference is invalid
+  console.log("Payment not confirmed:", result.status, result.data.status);
 }
 */

--- a/specs/payment/kadevpay/verify_payment/schema.json
+++ b/specs/payment/kadevpay/verify_payment/schema.json
@@ -81,6 +81,7 @@
     "Use the SECRET key (kdvs_*), not the public key — using the wrong key returns 401.",
     "reference is passed as a path parameter: GET /api/v1/transactions/verify/{reference}, not in the request body.",
     "Never fulfill an order until data.status === 'paid' — always verify server-side after the onSuccess callback or callback_url redirect.",
+    "Pass the reference directly as a path segment — do not URL-encode it. The format KDV-* contains only safe characters.",
     "mode: 'test' appears in sandbox responses — check this field to distinguish test vs live transactions."
   ]
 }

--- a/specs/payment/kadevpay/verify_payment/schema.json
+++ b/specs/payment/kadevpay/verify_payment/schema.json
@@ -3,7 +3,7 @@
   "provider_api_version": "v1",
   "capability": "verify_payment",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "ready",
   "currency": ["XOF"],
   "auth": {
     "type": "api_key",

--- a/specs/payment/kadevpay/verify_payment/schema.json
+++ b/specs/payment/kadevpay/verify_payment/schema.json
@@ -80,7 +80,7 @@
   "gotchas": [
     "Use the SECRET key (kdvs_*), not the public key — using the wrong key returns 401.",
     "reference is passed as a path parameter: GET /api/v1/transactions/verify/{reference}, not in the request body.",
-    "Never fulfill an order until data.status === 'paid' — always verify server-side after the onSuccess callback or callback_url redirect.",
+    "Check both conditions before fulfilling: top-level status === 'success' AND data.status === 'paid'. Checking only data.status is not sufficient — an invalid reference can return a non-success top-level status.",
     "Pass the reference directly as a path segment — do not URL-encode it. The format KDV-* contains only safe characters.",
     "mode: 'test' appears in sandbox responses — check this field to distinguish test vs live transactions."
   ]

--- a/specs/payment/kadevpay/verify_payment/schema.json
+++ b/specs/payment/kadevpay/verify_payment/schema.json
@@ -1,0 +1,86 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "v1",
+  "capability": "verify_payment",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "currency": ["XOF"],
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "Authorization",
+    "format": "Bearer {token}",
+    "env_var": "KADEVPAY_SECRET_KEY"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://pay.kadev.ci/api/v1/transactions/verify/{reference}"
+  },
+  "example_prompt": "Verify a KadevPay transaction server-side and confirm its status before fulfilling an order.",
+  "input_schema": {
+    "type": "object",
+    "required": ["reference"],
+    "properties": {
+      "reference": {
+        "type": "string",
+        "description": "Transaction reference from the checkout onSuccess callback, e.g. KDV-1775413916000 — passed as path parameter"
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "required": ["status", "data"],
+    "properties": {
+      "status": {
+        "type": "string",
+        "description": "Top-level result, e.g. 'success'"
+      },
+      "mode": {
+        "type": "string",
+        "enum": ["test", "live"]
+      },
+      "data": {
+        "type": "object",
+        "required": ["reference", "status", "amount", "currency"],
+        "properties": {
+          "reference": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": ["paid", "pending", "failed"]
+          },
+          "amount": {
+            "type": "number",
+            "description": "Gross amount in XOF"
+          },
+          "currency": {
+            "type": "string",
+            "enum": ["XOF"]
+          },
+          "customer": {
+            "type": "object",
+            "properties": {
+              "full_name": { "type": "string" },
+              "email": { "type": "string" }
+            }
+          },
+          "paid_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "message": { "type": "string" }
+    }
+  },
+  "gotchas": [
+    "Use the SECRET key (kdvs_*), not the public key — using the wrong key returns 401.",
+    "reference is passed as a path parameter: GET /api/v1/transactions/verify/{reference}, not in the request body.",
+    "Never fulfill an order until data.status === 'paid' — always verify server-side after the onSuccess callback or callback_url redirect.",
+    "mode: 'test' appears in sandbox responses — check this field to distinguish test vs live transactions."
+  ]
+}

--- a/specs/payment/kadevpay/webhook_payment_success/canonical_example.ts
+++ b/specs/payment/kadevpay/webhook_payment_success/canonical_example.ts
@@ -31,9 +31,12 @@ interface KadevPayWebhookPayload {
   data: WebhookData;
 }
 
-export function verifyWebhookSignature(rawBody: string, signature: string): boolean {
+export function verifyWebhookSignature(
+  body: KadevPayWebhookPayload,
+  signature: string
+): boolean {
   const expected = createHmac("sha512", KADEVPAY_WEBHOOK_SECRET as string)
-    .update(rawBody)
+    .update(JSON.stringify(body))
     .digest("hex");
   try {
     return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
@@ -52,21 +55,18 @@ export function handleWebhook(payload: KadevPayWebhookPayload): void {
 /*
 Usage example (Express.js handler):
 
-app.post("/webhooks/kadevpay", express.raw({ type: "application/json" }), (req, res) => {
-  // Return 200 immediately — process asynchronously
-  res.sendStatus(200);
+app.post("/webhooks/kadevpay", express.json(), (req, res) => {
+  const signature = req.headers["x-kadevpay-signature"] as string;
+  const payload: KadevPayWebhookPayload = req.body;
 
-  const rawBody = req.body.toString();
-  const signature = req.headers["x_kadevpay_signature"] as string;
-
-  if (!verifyWebhookSignature(rawBody, signature)) {
-    console.error("Invalid KadevPay webhook signature — request rejected");
-    return;
+  if (!verifyWebhookSignature(payload, signature)) {
+    return res.status(401).send("Signature invalide");
   }
 
-  const payload: KadevPayWebhookPayload = JSON.parse(rawBody);
+  // Return 200 immediately — process asynchronously
+  res.status(200).send("Webhook traité");
 
-  if (payload.event !== "payment.success") return;
+  if (payload.event !== "payment.success" || payload.data.status !== "paid") return;
 
   // Always verify server-side before fulfilling the order
   verifyPayment(payload.data.reference).then((result) => {

--- a/specs/payment/kadevpay/webhook_payment_success/canonical_example.ts
+++ b/specs/payment/kadevpay/webhook_payment_success/canonical_example.ts
@@ -1,0 +1,79 @@
+/**
+ * @provider KadevPay
+ * @capability webhook_payment_success
+ * @atss 1.0
+ * @capability_type webhook
+ */
+
+import { createHmac, timingSafeEqual } from "crypto";
+
+const KADEVPAY_WEBHOOK_SECRET = process.env.KADEVPAY_WEBHOOK_SECRET;
+if (!KADEVPAY_WEBHOOK_SECRET) throw new Error("Missing env: KADEVPAY_WEBHOOK_SECRET");
+
+interface WebhookCustomer {
+  full_name?: string;
+  email?: string;
+  phone?: string;
+}
+
+interface WebhookData {
+  reference: string;
+  amount: number;
+  net_amount?: number;
+  currency: "XOF";
+  status: "paid";
+  customer?: WebhookCustomer;
+  metadata?: Record<string, unknown>;
+}
+
+interface KadevPayWebhookPayload {
+  event: "payment.success";
+  data: WebhookData;
+}
+
+export function verifyWebhookSignature(rawBody: string, signature: string): boolean {
+  const expected = createHmac("sha512", KADEVPAY_WEBHOOK_SECRET as string)
+    .update(rawBody)
+    .digest("hex");
+  try {
+    return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}
+
+export function handleWebhook(payload: KadevPayWebhookPayload): void {
+  if (payload.event !== "payment.success") return;
+
+  const { reference, amount, net_amount } = payload.data;
+  console.log(`Payment success: ${reference}, amount=${amount} XOF, net=${net_amount ?? amount} XOF`);
+}
+
+/*
+Usage example (Express.js handler):
+
+app.post("/webhooks/kadevpay", express.raw({ type: "application/json" }), (req, res) => {
+  // Return 200 immediately — process asynchronously
+  res.sendStatus(200);
+
+  const rawBody = req.body.toString();
+  const signature = req.headers["x_kadevpay_signature"] as string;
+
+  if (!verifyWebhookSignature(rawBody, signature)) {
+    console.error("Invalid KadevPay webhook signature — request rejected");
+    return;
+  }
+
+  const payload: KadevPayWebhookPayload = JSON.parse(rawBody);
+
+  if (payload.event !== "payment.success") return;
+
+  // Always verify server-side before fulfilling the order
+  verifyPayment(payload.data.reference).then((result) => {
+    if (result.data.status === "paid") {
+      // Fulfill the order — use net_amount for accounting (amount after 3% fee)
+      handleWebhook(payload);
+    }
+  });
+});
+*/

--- a/specs/payment/kadevpay/webhook_payment_success/schema.json
+++ b/specs/payment/kadevpay/webhook_payment_success/schema.json
@@ -8,7 +8,7 @@
   "auth": {
     "type": "none",
     "location": "header",
-    "field": "X_KADEVPAY_SIGNATURE",
+    "field": "x-kadevpay-signature",
     "format": "{token}",
     "env_var": "KADEVPAY_WEBHOOK_SECRET"
   },
@@ -64,7 +64,7 @@
   "response_schema": {},
   "error_schema": {},
   "gotchas": [
-    "Verify the signature: compute HMAC-SHA512(rawBody, KADEVPAY_WEBHOOK_SECRET) and compare with the X_KADEVPAY_SIGNATURE header — use SHA-512, not SHA-256.",
+    "Verify the signature: compute HMAC-SHA512(JSON.stringify(req.body), KADEVPAY_WEBHOOK_SECRET) and compare with the x-kadevpay-signature header — hash the re-serialized parsed body, not the raw request string. Use SHA-512, not SHA-256.",
     "Only act on event === 'payment.success' — other event types may be added by KadevPay in the future.",
     "net_amount is the actual revenue after KadevPay's 3% fee — use it for accounting, not amount.",
     "Always call verify_payment server-side after receiving the webhook — never fulfill based on the webhook payload alone.",

--- a/specs/payment/kadevpay/webhook_payment_success/schema.json
+++ b/specs/payment/kadevpay/webhook_payment_success/schema.json
@@ -3,7 +3,7 @@
   "provider_api_version": "v1",
   "capability": "webhook_payment_success",
   "capability_type": "webhook",
-  "status": "draft",
+  "status": "ready",
   "currency": ["XOF"],
   "auth": {
     "type": "none",

--- a/specs/payment/kadevpay/webhook_payment_success/schema.json
+++ b/specs/payment/kadevpay/webhook_payment_success/schema.json
@@ -1,0 +1,73 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "v1",
+  "capability": "webhook_payment_success",
+  "capability_type": "webhook",
+  "status": "draft",
+  "currency": ["XOF"],
+  "auth": {
+    "type": "none",
+    "location": "header",
+    "field": "X_KADEVPAY_SIGNATURE",
+    "format": "{token}",
+    "env_var": "KADEVPAY_WEBHOOK_SECRET"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "{your_webhook_url}"
+  },
+  "example_prompt": "Receive and verify a KadevPay payment.success webhook event before fulfilling an order.",
+  "input_schema": {
+    "type": "object",
+    "required": ["event", "data"],
+    "properties": {
+      "event": {
+        "type": "string",
+        "enum": ["payment.success"]
+      },
+      "data": {
+        "type": "object",
+        "required": ["reference", "amount", "currency", "status"],
+        "properties": {
+          "reference": { "type": "string" },
+          "amount": {
+            "type": "number",
+            "description": "Gross amount in XOF"
+          },
+          "net_amount": {
+            "type": "number",
+            "description": "Amount after KadevPay 3% fee in XOF"
+          },
+          "currency": {
+            "type": "string",
+            "enum": ["XOF"]
+          },
+          "status": {
+            "type": "string",
+            "enum": ["paid"]
+          },
+          "customer": {
+            "type": "object",
+            "properties": {
+              "full_name": { "type": "string" },
+              "email": { "type": "string" },
+              "phone": { "type": "string" }
+            }
+          },
+          "metadata": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  },
+  "response_schema": {},
+  "error_schema": {},
+  "gotchas": [
+    "Verify the signature: compute HMAC-SHA512(rawBody, KADEVPAY_WEBHOOK_SECRET) and compare with the X_KADEVPAY_SIGNATURE header — use SHA-512, not SHA-256.",
+    "Only act on event === 'payment.success' — other event types may be added by KadevPay in the future.",
+    "net_amount is the actual revenue after KadevPay's 3% fee — use it for accounting, not amount.",
+    "Always call verify_payment server-side after receiving the webhook — never fulfill based on the webhook payload alone.",
+    "Return HTTP 200 immediately; process the event asynchronously. The webhook URL must be HTTPS and configured in the KadevPay dashboard."
+  ]
+}


### PR DESCRIPTION
Closes #46.

## Summary

- Adds `sdk` as a new ATSS `capability_type` in `validate.js` and `ATSS.md` — for providers that only expose a client-side JS SDK with no direct HTTP endpoint
- Adds KadevPay provider (CI, XOF) with 3 capabilities:
  - `create_checkout_session` (`sdk`) — exports `buildCheckoutConfig()` server-side; SDK invocation shown in usage comment
  - `verify_payment` (`synchronous`) — `GET /api/v1/transactions/verify/{reference}` with secret key; response schema verified against real API
  - `webhook_payment_success` (`webhook`) — HMAC-SHA512 signature verification, `net_amount` after 3% fee
- Fixes `encodeURIComponent` on path params in `djomy/get_payment_link` and `kadevpay/verify_payment` + gotchas added
- Adds rule in `CLAUDE.md`: never `encodeURIComponent` path parameters unless docs require it

## Test plan

- [x] `npm run validate` — 134 passed, 0 failed
- [x] All 3 KadevPay specs pass per-spec and cross-spec checks
- [x] `canonical_example.ts` files compile with `tsc --noEmit`