### PR TITLE
fix(paygate): apply review corrections post-merge

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -643,8 +643,8 @@ function runCrossSpecChecks(loadedSchemas) {
         );
       }
       if (schema.provider_api_version !== majApiVer) {
-        errors.push(
-          `[CROSS-SPEC] provider_api_version: "${schema.provider_api_version}" (majoritaire: "${majApiVer}")`
+        console.warn(
+          `        [WARN] provider_api_version: "${schema.provider_api_version}" diffère de la valeur majoritaire "${majApiVer}" — normal si le provider a des endpoints v1/v2 en parallèle`
         );
       }
       if (String(providerManifest.sandbox) !== majSandbox) {

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -644,7 +644,7 @@ function runCrossSpecChecks(loadedSchemas) {
       }
       if (schema.provider_api_version !== majApiVer) {
         console.warn(
-          `        [WARN] provider_api_version: "${schema.provider_api_version}" diffère de la valeur majoritaire "${majApiVer}" — normal si le provider a des endpoints v1/v2 en parallèle`
+          `        [WARN] provider_api_version: "${schema.provider_api_version}" differs from the most common value "${majApiVer}" — expected when a provider exposes v1 and v2 endpoints in parallel`
         );
       }
       if (String(providerManifest.sandbox) !== majSandbox) {

--- a/specs/payment/paygate/check_payment_status/schema.json
+++ b/specs/payment/paygate/check_payment_status/schema.json
@@ -1,6 +1,6 @@
 {
   "spec_version": "1.0",
-  "provider_api_version": "v1",
+  "provider_api_version": "v2",
   "capability": "check_payment_status",
   "capability_type": "synchronous",
   "status": "ready",

--- a/specs/payment/paygate/create_payment_page/schema.json
+++ b/specs/payment/paygate/create_payment_page/schema.json
@@ -84,6 +84,7 @@
     "After the customer completes (or abandons) the payment, PayGate redirects to the url query parameter. The redirect URL alone is NOT proof of payment — always re-verify server-side with check_payment_status before fulfilling.",
     "If you also configured a webhook in your dashboard, you will receive the webhook on success regardless of whether the customer made it back to the redirect URL. The webhook is the more reliable signal.",
     "Use this capability instead of initiate_payment when you want to let the customer choose their operator on a PayGate-hosted page rather than knowing the network upfront.",
-    "[MUST TELL USER] PayGate API documentation is private and only visible from inside the merchant dashboard. The query parameters and behavior of /v1/page may evolve — cross-check with the current docs in your account."
+    "[MUST TELL USER] PayGate API documentation is private and only visible from inside the merchant dashboard. The query parameters and behavior of /v1/page may evolve — cross-check with the current docs in your account.",
+    "This endpoint uses /v1/page (no /api/ prefix), unlike all other PayGate endpoints which go through /api/. If you centralize BASE_URL as 'https://paygateglobal.com/api', this call will break silently."
   ]
 }

--- a/specs/payment/paygate/webhook_payment_completed/canonical_example.ts
+++ b/specs/payment/paygate/webhook_payment_completed/canonical_example.ts
@@ -26,7 +26,11 @@ interface VerifiedPayment {
   identifier: string;
   tx_reference: string;
   payment_reference: string;
-  amount: number;
+  // The amount comes straight from the UNSIGNED webhook and is NOT confirmed by
+  // /v2/status (which returns no amount field). Never fulfill based on this value —
+  // reconcile against the amount you stored at initiate_payment time, keyed by
+  // identifier. Kept here only for logging / comparison.
+  untrustedAmount: number;
   payment_method: PayGatePaymentMethod;
   datetime: string;
 }
@@ -84,7 +88,7 @@ export async function handlePayGateWebhook(
     identifier: payload.identifier,
     tx_reference: String(verified.tx_reference ?? payload.tx_reference),
     payment_reference: String(verified.payment_reference ?? payload.payment_reference),
-    amount: payload.amount,
+    untrustedAmount: payload.amount,
     payment_method: verified.payment_method ?? payload.payment_method,
     datetime: verified.datetime ?? payload.datetime,
   };
@@ -98,14 +102,23 @@ app.post("/webhooks/paygate", express.text({ type: "*\/*" }), async (req, res) =
   try {
     const payment = await handlePayGateWebhook(req.body as string);
     if (payment) {
-      // payment.status was verified server-side as paid — safe to fulfill the order
-      await fulfillOrder(payment.identifier, payment);
+      // The webhook is unsigned and /v2/status returns no amount, so
+      // verify the AMOUNT against what you stored when you called initiate_payment.
+      const order = await getOrderByIdentifier(payment.identifier);
+      if (order && order.amount === payment.untrustedAmount) {
+        await fulfillOrder(payment.identifier, payment);
+      } else {
+        console.warn("Amount mismatch — refusing to fulfill:", payment.identifier);
+      }
     }
   } catch (err) {
     console.error("PayGate webhook handler failed:", err);
   }
 });
 
-// Always re-verify with check_payment_status before fulfilling — PayGate webhooks
-// are NOT cryptographically signed, so the payload alone is not proof of payment.
+// PayGate webhooks are NOT cryptographically signed — handlePayGateWebhook always
+// re-verifies via /v2/status before treating a payment as completed.
+// That confirms the payment SUCCEEDED but NOT the amount (no amount field in the
+// status response), so always reconcile payment.untrustedAmount against your
+// stored order amount before fulfilling.
 */

--- a/specs/payment/paygate/webhook_payment_completed/schema.json
+++ b/specs/payment/paygate/webhook_payment_completed/schema.json
@@ -64,6 +64,7 @@
     "PayGate may retry or drop webhooks in case of timeouts or 5xx responses. Implement a reconciliation job that re-polls /v2/status for any PENDING transaction older than a few minutes.",
     "Return HTTP 200 immediately and process asynchronously if your handler is slow. Anything other than 200 is treated as a delivery failure.",
     "payment_method on this payload uses 'T-Money' (with hyphen), NOT 'TMONEY'. Same caveat as on the /v2/status response — do not assume it matches the value you sent on /v1/pay.",
-    "Restrict the webhook endpoint to PayGate's outbound IP range if possible, and rate-limit it — there is no other defense-in-depth available since there is no signature."
+    "Restrict the webhook endpoint to PayGate's outbound IP range if possible, and rate-limit it — there is no other defense-in-depth available since there is no signature.",
+    "The `amount` field in the webhook payload cannot be verified against the API — /v2/status does not return an amount. Always compare against the amount stored in your database at order creation, never trust the webhook value directly."
   ]
 }


### PR DESCRIPTION
## Summary

- `check_payment_status/schema.json`: `provider_api_version` `v1` → `v2` (l'endpoint est `/api/v2/status`)
- `webhook_payment_completed`: renommage `amount` → `untrustedAmount` dans `VerifiedPayment`, ajout vérification DB dans l'exemple d'usage, gotcha sur le montant non vérifiable
- `create_payment_page`: gotcha sur l'absence du préfixe `/api/` contrairement aux autres endpoints PayGate
- `scripts/validate.js`: check cross-spec `provider_api_version` passé en warning (un provider peut légitimement exposer des endpoints v1 et v2 en parallèle)

Closes the review comments left on #49 after merge.