### PR TITLE
chore(bictorys): promote 4 specs from draft to ready

### DIFF
--- a/specs/payment/bictorys/create_charge/schema.json
+++ b/specs/payment/bictorys/create_charge/schema.json
@@ -3,7 +3,7 @@
   "provider_api_version": "2026-06-05",
   "capability": "create_charge",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "ready",
   "currency": ["XOF", "XAF", "GNF", "NGN"],
   "auth": {
     "type": "api_key",

--- a/specs/payment/bictorys/create_payout/schema.json
+++ b/specs/payment/bictorys/create_payout/schema.json
@@ -3,7 +3,7 @@
   "provider_api_version": "2026-06-05",
   "capability": "create_payout",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "ready",
   "currency": ["XOF", "XAF", "GNF", "NGN"],
   "auth": {
     "type": "api_key",

--- a/specs/payment/bictorys/verify_transaction/schema.json
+++ b/specs/payment/bictorys/verify_transaction/schema.json
@@ -3,7 +3,7 @@
   "provider_api_version": "2026-06-05",
   "capability": "verify_transaction",
   "capability_type": "synchronous",
-  "status": "draft",
+  "status": "ready",
   "currency": ["XOF", "XAF", "GNF", "NGN"],
   "auth": {
     "type": "api_key",

--- a/specs/payment/bictorys/webhook_payment_completed/schema.json
+++ b/specs/payment/bictorys/webhook_payment_completed/schema.json
@@ -3,7 +3,7 @@
   "provider_api_version": "2026-06-05",
   "capability": "webhook_payment_completed",
   "capability_type": "webhook",
-  "status": "draft",
+  "status": "ready",
   "currency": ["XOF", "XAF", "GNF", "NGN"],
   "auth": {
     "type": "none",


### PR DESCRIPTION
## Summary

- Promotes `create_charge`, `create_payout`, `verify_transaction`, and `webhook_payment_completed` from `draft` to `ready`
- All 4 specs pass `npm run validate` with zero errors

## Test plan

- [ ] `npm run validate` passes (verified locally)
- [ ] Specs are visible in the MCP server after merge