### PR TITLE
feat(africastalking): add SMS specs — 9 capabilities

### DIFF
--- a/scripts/test_live.py
+++ b/scripts/test_live.py
@@ -117,7 +117,7 @@ def build_auth(schema, fixture):
 
 # ── HTTP ──────────────────────────────────────────────────────────────────────
 
-def http_call(method, url, auth_headers, body=None, extra_headers=None):
+def http_call(method, url, auth_headers, body=None, extra_headers=None, content_type="application/json"):
     headers = {
         "Accept": "application/json",
         "X-Trace-Id": f"afrotools-live-{int(time.time() * 1000)}",
@@ -133,8 +133,12 @@ def http_call(method, url, auth_headers, body=None, extra_headers=None):
             headers[k] = v
     data = None
     if body is not None:
-        data = json.dumps(body).encode()
-        headers["Content-Type"] = "application/json"
+        if content_type == "application/x-www-form-urlencoded":
+            data = urllib.parse.urlencode({k: v for k, v in body.items() if v is not None}).encode()
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        else:
+            data = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
         with urllib.request.urlopen(req, context=_SSL_CTX) as r:
@@ -360,14 +364,15 @@ def run(provider_slug, only_capability=None, raw_capability=None):
             body[body_auth[0]] = body_auth[1]
 
         extra_headers = resolve(step.get("headers", {}), stored, ts)
+        content_type = step.get("content_type", "application/json")
 
         if raw_capability == cap_name:
-            _, resp = http_call(method, url, auth_headers, body, extra_headers)
+            _, resp = http_call(method, url, auth_headers, body, extra_headers, content_type)
             print(f"\n{BOLD}Raw response:{RESET}")
             print(json.dumps(resp, indent=2))
             return
 
-        status_code, resp = http_call(method, url, auth_headers, body, extra_headers)
+        status_code, resp = http_call(method, url, auth_headers, body, extra_headers, content_type)
 
         store_as = step.get("store_as")
         if store_as:

--- a/specs/CLAUDE.md
+++ b/specs/CLAUDE.md
@@ -74,7 +74,7 @@ Every spec folder must contain exactly these two files. Nothing else.
 | provider_slug | string | Lowercase, no dashes, no spaces |
 | provider_api_version | string | YYYY-MM-DD if provider has no version string |
 | capability_type | enum | `synchronous`, `asynchronous`, or `webhook` |
-| status | enum | `draft`, `compliant`, `verified`, `deprecated`, `archived` |
+| status | enum | `draft`, `ready`, `verified`, `deprecated`, `archived` |
 | country_code | string[] | ISO 3166-1 alpha-2 codes |
 | currency | string[] | ISO 4217 codes |
 | sandbox | boolean | true if provider has a sandbox environment |

--- a/specs/sms/africastalking/create_subscription/canonical_example.ts
+++ b/specs/sms/africastalking/create_subscription/canonical_example.ts
@@ -1,0 +1,104 @@
+/**
+ * @provider Africa's Talking
+ * @capability create_subscription
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const AFRICASTALKING_API_KEY = process.env.AFRICASTALKING_API_KEY;
+const AFRICASTALKING_USERNAME = process.env.AFRICASTALKING_USERNAME;
+if (!AFRICASTALKING_API_KEY) throw new Error("Missing env: AFRICASTALKING_API_KEY");
+if (!AFRICASTALKING_USERNAME) throw new Error("Missing env: AFRICASTALKING_USERNAME");
+
+const isSandbox = process.env.AFRICASTALKING_SANDBOX === "true";
+// Production: content.africastalking.com — NOT api.africastalking.com (common mistake)
+// Sandbox:    api.sandbox.africastalking.com
+const SUBSCRIPTION_BASE = isSandbox
+  ? "https://api.sandbox.africastalking.com"
+  : "https://content.africastalking.com";
+
+interface CreateSubscriptionInput {
+  shortCode: string;
+  keyword?: string;
+  requestId?: string;
+  redirectUrl?: string;
+  phoneNumber?: string;
+  sourceIP?: string;
+  userAgent?: string;
+}
+
+interface CreateSubscriptionResponse {
+  responseCode: string;
+  status: string;
+  transactionId: string;
+  /** Only present in HE (Header Enrichment) mode. Absent in Subscribe Manage mode. */
+  url?: string;
+}
+
+interface AfricasTalkingSubscriptionError {
+  responseCode: string;
+  status: string;
+}
+
+export async function createSubscription(
+  input: CreateSubscriptionInput
+): Promise<CreateSubscriptionResponse> {
+  const params = new URLSearchParams();
+  params.set("username", AFRICASTALKING_USERNAME!);
+  params.set("shortCode", input.shortCode);
+  if (input.keyword !== undefined) params.set("keyword", input.keyword);
+  if (input.requestId !== undefined) params.set("requestId", input.requestId);
+  if (input.redirectUrl !== undefined) params.set("redirectUrl", input.redirectUrl);
+  if (input.phoneNumber !== undefined) params.set("phoneNumber", input.phoneNumber);
+  if (input.sourceIP !== undefined) params.set("sourceIP", input.sourceIP);
+  if (input.userAgent !== undefined) params.set("userAgent", input.userAgent);
+
+  const url = `${SUBSCRIPTION_BASE}/version1/subscription/safaricom`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      apiKey: AFRICASTALKING_API_KEY!,
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: params.toString(),
+  });
+
+  const data: CreateSubscriptionResponse | AfricasTalkingSubscriptionError =
+    await response.json();
+
+  if (!response.ok || (data as CreateSubscriptionResponse).responseCode !== "Success") {
+    const err = data as AfricasTalkingSubscriptionError;
+    throw new Error(
+      `Africa's Talking subscription error: responseCode=${err.responseCode}, status=${err.status}`
+    );
+  }
+
+  return data as CreateSubscriptionResponse;
+}
+
+/*
+Usage example:
+
+// HE mode (user on Safaricom mobile data) — response includes url for redirect
+// Subscribe Manage mode (user on Wi-Fi or non-Safaricom) — response has no url field
+const result = await createSubscription({
+  shortCode: "12345",
+  keyword: "NEWS",
+  phoneNumber: "+254711082282",
+  requestId: "req_abc123",
+  redirectUrl: "https://myapp.com/subscription-confirmed",
+});
+
+console.log(`transactionId: ${result.transactionId}`);
+if (result.url) {
+  // HE mode: redirect the user to result.url to confirm subscription
+  console.log(`Redirect user to: ${result.url}`);
+} else {
+  // Subscribe Manage mode: user receives a USSD prompt on their device
+  console.log("USSD prompt sent to user's device");
+}
+
+// Set AFRICASTALKING_SANDBOX=true to use the sandbox environment
+// Production URL: content.africastalking.com (NOT api.africastalking.com)
+*/

--- a/specs/sms/africastalking/create_subscription/schema.json
+++ b/specs/sms/africastalking/create_subscription/schema.json
@@ -1,0 +1,99 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "2024-01-01",
+  "capability": "create_subscription",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "currency": ["KES", "NGN", "TZS", "UGX", "RWF", "MWK"],
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "apiKey",
+    "format": "{token}",
+    "env_var": "AFRICASTALKING_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://content.africastalking.com/version1/subscription/safaricom"
+  },
+  "example_prompt": "Create a Safaricom premium SMS subscription for a Kenyan phone number using Africa's Talking.",
+  "input_schema": {
+    "type": "object",
+    "required": ["username", "shortCode"],
+    "properties": {
+      "username": {
+        "type": "string",
+        "description": "Africa's Talking application username."
+      },
+      "shortCode": {
+        "type": "string",
+        "description": "Valid shortcode registered with Africa's Talking for Safaricom."
+      },
+      "keyword": {
+        "type": "string",
+        "description": "Keyword associated with the shortcode."
+      },
+      "requestId": {
+        "type": "string",
+        "description": "Client-specified identifier echoed in the delivery report (DLR) callback."
+      },
+      "redirectUrl": {
+        "type": "string",
+        "description": "URL the user is redirected to after confirming the subscription."
+      },
+      "phoneNumber": {
+        "type": "string",
+        "description": "Phone number to subscribe in E.164 format (e.g. +254711082282)."
+      },
+      "sourceIP": {
+        "type": "string",
+        "description": "IP address of the subscribing party."
+      },
+      "userAgent": {
+        "type": "string",
+        "description": "Browser user agent string of the subscribing party."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "required": ["responseCode", "status", "transactionId"],
+    "properties": {
+      "responseCode": {
+        "type": "string",
+        "description": "Result of the request. 'Success' indicates the subscription was initiated."
+      },
+      "status": {
+        "type": "string",
+        "description": "Subscription status. Typically 'Sent' when the request is accepted."
+      },
+      "transactionId": {
+        "type": "string",
+        "description": "Unique identifier for the subscription transaction."
+      },
+      "url": {
+        "type": "string",
+        "description": "Redirect URL returned only in HE (Header Enrichment) mode. Absent in Subscribe Manage mode."
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "required": ["responseCode", "status"],
+    "properties": {
+      "responseCode": {
+        "type": "string",
+        "description": "Non-Success response code indicating why the request failed."
+      },
+      "status": {
+        "type": "string",
+        "description": "Error status description."
+      }
+    }
+  },
+  "gotchas": [
+    "This endpoint is Safaricom-specific (Kenya only). The URL path includes /safaricom — there is no generic subscription endpoint across all carriers.",
+    "Production uses content.africastalking.com, NOT api.africastalking.com. Sandbox uses api.sandbox.africastalking.com. The domain difference is a common integration mistake.",
+    "Two subscription modes exist: HE (Header Enrichment) requires the user to be on Safaricom mobile data and returns a redirect url; Subscribe Manage sends a USSD prompt. The mode is determined by Safaricom's routing — you cannot choose it explicitly. Only HE responses include the url field."
+  ]
+}

--- a/specs/sms/africastalking/create_subscription/schema.json
+++ b/specs/sms/africastalking/create_subscription/schema.json
@@ -4,7 +4,7 @@
   "capability": "create_subscription",
   "capability_type": "synchronous",
   "status": "draft",
-  "currency": ["KES", "NGN", "TZS", "UGX", "RWF", "MWK"],
+  "currency": ["EGP", "GHS", "KES", "LSL", "MWK", "NAD", "NGN", "RWF", "SZL", "TZS", "UGX", "XOF", "ZAR", "ZMW"],
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/sms/africastalking/fetch_messages/canonical_example.ts
+++ b/specs/sms/africastalking/fetch_messages/canonical_example.ts
@@ -1,0 +1,94 @@
+/**
+ * @provider Africa's Talking
+ * @capability fetch_messages
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const AFRICASTALKING_API_KEY = process.env.AFRICASTALKING_API_KEY;
+const AFRICASTALKING_USERNAME = process.env.AFRICASTALKING_USERNAME;
+if (!AFRICASTALKING_API_KEY) throw new Error("Missing env: AFRICASTALKING_API_KEY");
+if (!AFRICASTALKING_USERNAME) throw new Error("Missing env: AFRICASTALKING_USERNAME");
+
+const isSandbox = process.env.AFRICASTALKING_SANDBOX === "true";
+const MESSAGING_BASE = isSandbox
+  ? "https://api.sandbox.africastalking.com"
+  : "https://api.africastalking.com";
+
+interface SMSMessage {
+  linkId: string;
+  text: string;
+  to: string;
+  id: number;
+  date: string;
+  from: string;
+}
+
+interface FetchMessagesResponse {
+  SMSMessageData: {
+    Messages: SMSMessage[];
+  };
+}
+
+interface AfricasTalkingFetchError {
+  message: string;
+}
+
+export async function fetchMessages(
+  lastReceivedId?: string
+): Promise<FetchMessagesResponse> {
+  const params = new URLSearchParams();
+  params.set("username", AFRICASTALKING_USERNAME!);
+  if (lastReceivedId !== undefined) {
+    params.set("lastReceivedId", lastReceivedId);
+  }
+
+  const url = `${MESSAGING_BASE}/version1/messaging?${params.toString()}`;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      apiKey: AFRICASTALKING_API_KEY!,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const error: AfricasTalkingFetchError = await response.json();
+    throw new Error(
+      `Africa's Talking fetch_messages error ${response.status}: ${error.message}`
+    );
+  }
+
+  return response.json() as Promise<FetchMessagesResponse>;
+}
+
+/*
+Usage example:
+
+// First call — fetch from the beginning (no lastReceivedId)
+const first = await fetchMessages();
+const messages = first.SMSMessageData.Messages;
+console.log(`Fetched ${messages.length} messages`);
+
+// Store the last id as the cursor for the next call
+let cursor: string | undefined;
+if (messages.length > 0) {
+  cursor = String(messages[messages.length - 1].id);
+}
+
+// Subsequent calls — pass cursor to avoid re-processing old messages
+if (cursor) {
+  const next = await fetchMessages(cursor);
+  const newMessages = next.SMSMessageData.Messages;
+  console.log(`Fetched ${newMessages.length} new messages since id=${cursor}`);
+
+  for (const msg of newMessages) {
+    console.log(`From ${msg.from}: ${msg.text} (received ${msg.date})`);
+    cursor = String(msg.id); // advance cursor
+  }
+}
+
+// Prefer webhook_incoming_sms over polling for real-time delivery.
+// Configure the callback URL in the AT dashboard:
+// SMS → SMS Callback URLs → Incoming Messages
+*/

--- a/specs/sms/africastalking/fetch_messages/schema.json
+++ b/specs/sms/africastalking/fetch_messages/schema.json
@@ -4,7 +4,7 @@
   "capability": "fetch_messages",
   "capability_type": "synchronous",
   "status": "ready",
-  "currency": ["KES", "NGN", "TZS", "UGX", "RWF", "MWK"],
+  "currency": ["EGP", "GHS", "KES", "LSL", "MWK", "NAD", "NGN", "RWF", "SZL", "TZS", "UGX", "XOF", "ZAR", "ZMW"],
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/sms/africastalking/fetch_messages/schema.json
+++ b/specs/sms/africastalking/fetch_messages/schema.json
@@ -1,0 +1,93 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "2024-01-01",
+  "capability": "fetch_messages",
+  "capability_type": "synchronous",
+  "status": "ready",
+  "currency": ["KES", "NGN", "TZS", "UGX", "RWF", "MWK"],
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "apiKey",
+    "format": "{token}",
+    "env_var": "AFRICASTALKING_API_KEY"
+  },
+  "endpoint": {
+    "method": "GET",
+    "url": "https://api.africastalking.com/version1/messaging"
+  },
+  "example_prompt": "Fetch incoming SMS messages from your Africa's Talking inbox incrementally.",
+  "input_schema": {
+    "type": "object",
+    "required": ["username"],
+    "properties": {
+      "username": {
+        "type": "string",
+        "description": "Africa's Talking application username."
+      },
+      "lastReceivedId": {
+        "type": "string",
+        "description": "ID of the last processed message. Defaults to '0' to fetch from the beginning of the inbox. Pass the last id value from the previous response to paginate incrementally."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "required": ["SMSMessageData"],
+    "properties": {
+      "SMSMessageData": {
+        "type": "object",
+        "required": ["Messages"],
+        "properties": {
+          "Messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["linkId", "text", "to", "id", "date", "from"],
+              "properties": {
+                "linkId": {
+                  "type": "string",
+                  "description": "Link identifier for the message."
+                },
+                "text": {
+                  "type": "string",
+                  "description": "Body of the received SMS."
+                },
+                "to": {
+                  "type": "string",
+                  "description": "Shortcode or phone number that received the message."
+                },
+                "id": {
+                  "type": "integer",
+                  "description": "Unique numeric ID for this message. Use as lastReceivedId in subsequent calls."
+                },
+                "date": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "ISO 8601 timestamp of when the message was received."
+                },
+                "from": {
+                  "type": "string",
+                  "description": "Phone number of the sender in E.164 format."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "object",
+    "properties": {
+      "message": {
+        "type": "string",
+        "description": "Error message string returned on HTTP 4xx responses."
+      }
+    }
+  },
+  "gotchas": [
+    "Africa's Talking strongly recommends using webhook notifications (webhook_incoming_sms) instead of polling this endpoint. Configure SMS → SMS Callback URLs → Incoming Messages in the AT dashboard for real-time delivery.",
+    "lastReceivedId is a cursor. Store the last id value from each response and pass it on the next call — omitting it (or passing 0) returns messages from the beginning of your inbox and may return already-processed messages."
+  ]
+}

--- a/specs/sms/africastalking/live_test_fixtures.json
+++ b/specs/sms/africastalking/live_test_fixtures.json
@@ -1,0 +1,23 @@
+{
+  "sandbox_base_url": "https://api.sandbox.africastalking.com",
+  "steps": [
+    {
+      "capability": "fetch_messages",
+      "method": "GET",
+      "query_params": {
+        "username": "sandbox",
+        "lastReceivedId": "0"
+      }
+    },
+    {
+      "capability": "send_sms",
+      "content_type": "application/x-www-form-urlencoded",
+      "body": {
+        "username": "sandbox",
+        "to": "$env:AFRICASTALKING_TEST_PHONE",
+        "message": "Afro.tools live test $ts",
+        "from": "$env:AFRICASTALKING_SENDER_ID"
+      }
+    }
+  ]
+}

--- a/specs/sms/africastalking/provider.json
+++ b/specs/sms/africastalking/provider.json
@@ -2,7 +2,7 @@
   "slug": "africastalking",
   "name": "Africa's Talking",
   "category": "sms",
-  "country_code": ["KE", "NG", "TZ", "UG", "RW", "MW"],
+  "country_code": ["BF", "BJ", "CI", "EG", "GH", "KE", "LS", "ML", "MW", "NA", "NE", "NG", "RW", "SN", "SZ", "TG", "TZ", "UG", "ZA", "ZM"],
   "website": "https://africastalking.com",
   "docs_url": "https://developers.africastalking.com/docs/sms/overview",
   "docs_public": true,

--- a/specs/sms/africastalking/provider.json
+++ b/specs/sms/africastalking/provider.json
@@ -1,0 +1,12 @@
+{
+  "slug": "africastalking",
+  "name": "Africa's Talking",
+  "category": "sms",
+  "country_code": ["KE", "NG", "TZ", "UG", "RW", "MW"],
+  "website": "https://africastalking.com",
+  "docs_url": "https://developers.africastalking.com/docs/sms/overview",
+  "docs_public": true,
+  "sandbox": true,
+  "description": "Africa's Talking is a pan-African communications platform offering SMS, USSD, voice, and airtime APIs across multiple African countries.",
+  "example_prompt": "Send an SMS notification to a Kenyan phone number using Africa's Talking."
+}

--- a/specs/sms/africastalking/send_bulk_sms/canonical_example.ts
+++ b/specs/sms/africastalking/send_bulk_sms/canonical_example.ts
@@ -1,0 +1,110 @@
+/**
+ * @provider Africa's Talking
+ * @capability send_bulk_sms
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const AFRICASTALKING_API_KEY = process.env.AFRICASTALKING_API_KEY;
+const AFRICASTALKING_USERNAME = process.env.AFRICASTALKING_USERNAME;
+if (!AFRICASTALKING_API_KEY) throw new Error("Missing env: AFRICASTALKING_API_KEY");
+if (!AFRICASTALKING_USERNAME) throw new Error("Missing env: AFRICASTALKING_USERNAME");
+
+// NOTE: The sandbox URL for /messaging/bulk is not yet available.
+// Use send_sms (legacy endpoint) for sandbox testing.
+const BULK_URL = "https://api.africastalking.com/version1/messaging/bulk";
+
+interface SendBulkSmsInput {
+  phoneNumbers: string | string[];
+  message: string;
+  senderId: string;
+  enqueue?: number;
+}
+
+interface SmsRecipient {
+  statusCode: number;
+  number: string;
+  status: string;
+  cost: string;
+  messageId: string;
+}
+
+interface SendSmsResponse {
+  SMSMessageData: {
+    Message: string;
+    Recipients: SmsRecipient[];
+  };
+}
+
+export async function sendBulkSms(input: SendBulkSmsInput): Promise<SendSmsResponse> {
+  const phoneNumbers = Array.isArray(input.phoneNumbers)
+    ? input.phoneNumbers.join(",")
+    : input.phoneNumbers;
+
+  const body: Record<string, string | number> = {
+    username: AFRICASTALKING_USERNAME!,
+    // IMPORTANT: field is "phoneNumbers" NOT "to" — using "to" silently fails
+    phoneNumbers,
+    message: input.message,
+    // senderId is required for this endpoint (unlike the legacy from field which was optional)
+    senderId: input.senderId,
+  };
+  if (input.enqueue !== undefined) body.enqueue = input.enqueue;
+
+  const response = await fetch(BULK_URL, {
+    method: "POST",
+    headers: {
+      apiKey: AFRICASTALKING_API_KEY!,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Africa's Talking bulk SMS error ${response.status}: ${errorText}`);
+  }
+
+  const result = (await response.json()) as SendSmsResponse;
+
+  // HTTP 200 does not guarantee delivery — check per-recipient statusCode
+  for (const recipient of result.SMSMessageData.Recipients) {
+    if (recipient.statusCode !== 101 && recipient.statusCode !== 102 && recipient.statusCode !== 100) {
+      console.warn(
+        `Recipient ${recipient.number} failed: statusCode=${recipient.statusCode} status=${recipient.status}`
+      );
+    }
+  }
+
+  return result;
+}
+
+/*
+Usage example:
+
+// Set env vars:
+//   AFRICASTALKING_API_KEY=your_production_key
+//   AFRICASTALKING_USERNAME=your_username
+//
+// NOTE: No sandbox support for this endpoint yet.
+// Use send_sms (legacy) for sandbox testing.
+
+const result = await sendBulkSms({
+  phoneNumbers: ["+254711XXXYYY", "+254733YYYZZZ"],
+  message: "Your order has shipped!",
+  senderId: "MyBrand",   // required — omitting returns an error
+  enqueue: 1,
+});
+
+console.log(result.SMSMessageData.Message);
+// "Sent to 2/2 Total Cost: KES 1.6000"
+
+for (const r of result.SMSMessageData.Recipients) {
+  console.log(`${r.number}: statusCode=${r.statusCode} cost=${r.cost}`);
+  // statusCode 101 = Sent (success)
+}
+
+// Pitfall: do NOT use field name "to" — this endpoint requires "phoneNumbers"
+// Pitfall: senderId is required here; legacy send_sms allows omitting "from"
+*/

--- a/specs/sms/africastalking/send_bulk_sms/schema.json
+++ b/specs/sms/africastalking/send_bulk_sms/schema.json
@@ -4,7 +4,7 @@
   "capability": "send_bulk_sms",
   "capability_type": "synchronous",
   "status": "draft",
-  "currency": ["KES", "NGN", "TZS", "UGX", "RWF", "MWK"],
+  "currency": ["EGP", "GHS", "KES", "LSL", "MWK", "NAD", "NGN", "RWF", "SZL", "TZS", "UGX", "XOF", "ZAR", "ZMW"],
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/sms/africastalking/send_bulk_sms/schema.json
+++ b/specs/sms/africastalking/send_bulk_sms/schema.json
@@ -1,0 +1,103 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "2024-01-01",
+  "capability": "send_bulk_sms",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "currency": ["KES", "NGN", "TZS", "UGX", "RWF", "MWK"],
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "apiKey",
+    "format": "{token}",
+    "env_var": "AFRICASTALKING_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.africastalking.com/version1/messaging/bulk"
+  },
+  "example_prompt": "Send bulk SMS using Africa's Talking new bulk endpoint (JSON-friendly, requires senderId).",
+  "input_schema": {
+    "type": "object",
+    "required": ["username", "phoneNumbers", "message", "senderId"],
+    "properties": {
+      "username": {
+        "type": "string",
+        "description": "Your Africa's Talking app username."
+      },
+      "phoneNumbers": {
+        "type": "string",
+        "description": "Comma-separated E.164 phone numbers. NOTE: this field is phoneNumbers, not to — using to silently fails."
+      },
+      "message": {
+        "type": "string",
+        "description": "SMS content to send."
+      },
+      "senderId": {
+        "type": "string",
+        "description": "Your registered sender ID (shortcode or alphanumeric). Required for this endpoint — unlike the legacy send_sms endpoint where from was optional."
+      },
+      "enqueue": {
+        "type": "integer",
+        "enum": [0, 1],
+        "default": 1,
+        "description": "Set to 1 to queue the message without waiting for telco acknowledgement (default)."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "required": ["SMSMessageData"],
+    "properties": {
+      "SMSMessageData": {
+        "type": "object",
+        "required": ["Message", "Recipients"],
+        "properties": {
+          "Message": {
+            "type": "string",
+            "description": "Summary message (e.g. \"Sent to 1/1 Total Cost: KES 0.8000\")."
+          },
+          "Recipients": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["statusCode", "number", "status", "cost", "messageId"],
+              "properties": {
+                "statusCode": {
+                  "type": "integer",
+                  "description": "Per-recipient delivery status code. 101=Sent, 102=Queued, 100=Processed, 401=RiskHold, 402=InvalidSenderId, 403=InvalidPhoneNumber, 404=UnsupportedNumberType, 405=InsufficientBalance, 406=UserInBlacklist, 407=CouldNotRoute, 409=DoNotDisturbRejection, 500=InternalServerError, 501=GatewayError, 502=RejectedByGateway."
+                },
+                "number": {
+                  "type": "string",
+                  "description": "Recipient phone number in E.164 format."
+                },
+                "status": {
+                  "type": "string",
+                  "description": "Human-readable status (e.g. \"Success\", \"DeliveryFailure\")."
+                },
+                "cost": {
+                  "type": "string",
+                  "description": "Cost for this recipient (e.g. \"KES 0.8000\")."
+                },
+                "messageId": {
+                  "type": "string",
+                  "description": "Unique message ID assigned by Africa's Talking."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "string",
+    "description": "HTTP 4xx responses return a plain error message string."
+  },
+  "gotchas": [
+    "The recipient field is phoneNumbers (not to). Using to silently fails — this differs from the legacy send_sms endpoint.",
+    "senderId is required for this endpoint, not optional. Omitting it returns an error. In the legacy endpoint (send_sms), the from field was optional.",
+    "The sandbox URL is coming soon — this endpoint has no sandbox support yet. Use send_sms (legacy) for sandbox testing in the meantime.",
+    "This endpoint accepts both application/x-www-form-urlencoded and application/json. Set Content-Type: application/json when sending a JSON body."
+  ]
+}

--- a/specs/sms/africastalking/send_bulk_sms/schema.json
+++ b/specs/sms/africastalking/send_bulk_sms/schema.json
@@ -42,6 +42,14 @@
         "enum": [0, 1],
         "default": 1,
         "description": "Set to 1 to queue the message without waiting for telco acknowledgement (default)."
+      },
+      "maskedNumber": {
+        "type": "string",
+        "description": "Hashed phone number for Safaricom Kenya. Use instead of phoneNumbers when sending to a masked subscriber. When set, phoneNumbers must be an empty array []."
+      },
+      "telco": {
+        "type": "string",
+        "description": "Service provider name when using maskedNumber. Example: 'Safaricom'. Required when maskedNumber is set."
       }
     }
   },
@@ -98,6 +106,7 @@
     "The recipient field is phoneNumbers (not to). Using to silently fails — this differs from the legacy send_sms endpoint.",
     "senderId is required for this endpoint, not optional. Omitting it returns an error. In the legacy endpoint (send_sms), the from field was optional.",
     "The sandbox URL is coming soon — this endpoint has no sandbox support yet. Use send_sms (legacy) for sandbox testing in the meantime.",
-    "This endpoint accepts both application/x-www-form-urlencoded and application/json. Set Content-Type: application/json when sending a JSON body."
+    "This endpoint accepts both application/x-www-form-urlencoded and application/json. Set Content-Type: application/json when sending a JSON body.",
+    "To send to a Safaricom hashed number, set maskedNumber to the hashed string, telco to 'Safaricom', and phoneNumbers to an empty array []. The senderId field becomes optional in this mode."
   ]
 }

--- a/specs/sms/africastalking/send_premium_sms/canonical_example.ts
+++ b/specs/sms/africastalking/send_premium_sms/canonical_example.ts
@@ -1,0 +1,123 @@
+/**
+ * @provider Africa's Talking
+ * @capability send_premium_sms
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const AFRICASTALKING_API_KEY = process.env.AFRICASTALKING_API_KEY;
+const AFRICASTALKING_USERNAME = process.env.AFRICASTALKING_USERNAME;
+if (!AFRICASTALKING_API_KEY) throw new Error("Missing env: AFRICASTALKING_API_KEY");
+if (!AFRICASTALKING_USERNAME) throw new Error("Missing env: AFRICASTALKING_USERNAME");
+
+const IS_SANDBOX = process.env.AFRICASTALKING_SANDBOX === "true";
+
+// IMPORTANT: Production uses content.africastalking.com, NOT api.africastalking.com.
+// Using api.africastalking.com for premium SMS will fail.
+// Sandbox uses api.sandbox.africastalking.com (standard sandbox domain).
+const PREMIUM_PRODUCTION_HOST = "content.africastalking.com";
+const PREMIUM_SANDBOX_HOST = "api.sandbox.africastalking.com";
+const PREMIUM_HOST = IS_SANDBOX ? PREMIUM_SANDBOX_HOST : PREMIUM_PRODUCTION_HOST;
+const PREMIUM_URL = `https://${PREMIUM_HOST}/version1/messaging`;
+
+interface SendPremiumSmsInput {
+  to: string | string[];
+  message: string;
+  from: string;
+  keyword?: string;
+  enqueue?: number;
+  linkId?: string;
+  retryDurationInHours?: number;
+  requestId?: string;
+}
+
+interface SmsRecipient {
+  statusCode: number;
+  number: string;
+  status: string;
+  cost: string;
+  messageId: string;
+}
+
+interface SendSmsResponse {
+  SMSMessageData: {
+    Message: string;
+    Recipients: SmsRecipient[];
+  };
+}
+
+export async function sendPremiumSms(input: SendPremiumSmsInput): Promise<SendSmsResponse> {
+  const to = Array.isArray(input.to) ? input.to.join(",") : input.to;
+
+  const params = new URLSearchParams();
+  // In sandbox mode, username must be the literal string "sandbox"
+  params.set("username", IS_SANDBOX ? "sandbox" : AFRICASTALKING_USERNAME!);
+  params.set("to", to);
+  params.set("message", input.message);
+  // from (registered shortcode) is required for premium SMS
+  params.set("from", input.from);
+  if (input.keyword !== undefined) params.set("keyword", input.keyword);
+  if (input.enqueue !== undefined) params.set("enqueue", String(input.enqueue));
+  if (input.linkId !== undefined) params.set("linkId", input.linkId);
+  if (input.retryDurationInHours !== undefined)
+    params.set("retryDurationInHours", String(input.retryDurationInHours));
+  if (input.requestId !== undefined) params.set("requestId", input.requestId);
+
+  const response = await fetch(PREMIUM_URL, {
+    method: "POST",
+    headers: {
+      apiKey: AFRICASTALKING_API_KEY!,
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Africa's Talking premium SMS error ${response.status}: ${errorText}`);
+  }
+
+  const result = (await response.json()) as SendSmsResponse;
+
+  // HTTP 200 does not guarantee delivery — check per-recipient statusCode
+  for (const recipient of result.SMSMessageData.Recipients) {
+    if (recipient.statusCode !== 101 && recipient.statusCode !== 102 && recipient.statusCode !== 100) {
+      console.warn(
+        `Recipient ${recipient.number} failed: statusCode=${recipient.statusCode} status=${recipient.status}`
+      );
+    }
+  }
+
+  return result;
+}
+
+/*
+Usage example:
+
+// Set env vars:
+//   AFRICASTALKING_API_KEY=your_key
+//   AFRICASTALKING_USERNAME=your_username
+//   AFRICASTALKING_SANDBOX=true   (omit or set to "false" for production)
+
+const result = await sendPremiumSms({
+  to: ["+254711XXXYYY"],
+  message: "Your premium subscription is active.",
+  from: "12345",           // registered shortcode — required for premium SMS
+  requestId: "order-789",  // echoed in DLR callback for correlation
+  keyword: "JOIN",
+  retryDurationInHours: 12,
+});
+
+console.log(result.SMSMessageData.Message);
+// "Sent to 1/1 Total Cost: KES 5.0000"
+
+for (const r of result.SMSMessageData.Recipients) {
+  console.log(`${r.number}: statusCode=${r.statusCode}`);
+  // statusCode 101 = Sent (success)
+}
+
+// IMPORTANT: Production uses content.africastalking.com — NOT api.africastalking.com
+// The requestId is echoed back in Africa's Talking's HTTP DLR callback
+// so you can match delivery reports to your sends.
+*/

--- a/specs/sms/africastalking/send_premium_sms/schema.json
+++ b/specs/sms/africastalking/send_premium_sms/schema.json
@@ -4,7 +4,7 @@
   "capability": "send_premium_sms",
   "capability_type": "synchronous",
   "status": "draft",
-  "currency": ["KES", "NGN", "TZS", "UGX", "RWF", "MWK"],
+  "currency": ["EGP", "GHS", "KES", "LSL", "MWK", "NAD", "NGN", "RWF", "SZL", "TZS", "UGX", "XOF", "ZAR", "ZMW"],
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/sms/africastalking/send_premium_sms/schema.json
+++ b/specs/sms/africastalking/send_premium_sms/schema.json
@@ -1,0 +1,118 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "2024-01-01",
+  "capability": "send_premium_sms",
+  "capability_type": "synchronous",
+  "status": "draft",
+  "currency": ["KES", "NGN", "TZS", "UGX", "RWF", "MWK"],
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "apiKey",
+    "format": "{token}",
+    "env_var": "AFRICASTALKING_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://content.africastalking.com/version1/messaging"
+  },
+  "example_prompt": "Send a premium-rate SMS to subscribers using Africa's Talking premium SMS endpoint.",
+  "input_schema": {
+    "type": "object",
+    "required": ["username", "to", "message", "from"],
+    "properties": {
+      "username": {
+        "type": "string",
+        "description": "Your Africa's Talking app username. Must be the literal string \"sandbox\" in sandbox mode."
+      },
+      "to": {
+        "type": "string",
+        "description": "Comma-separated E.164 phone numbers. Each number must include the + prefix."
+      },
+      "message": {
+        "type": "string",
+        "description": "SMS content to send."
+      },
+      "from": {
+        "type": "string",
+        "description": "Your registered shortcode. Required for premium SMS — unlike bulk SMS where the sender ID was optional."
+      },
+      "keyword": {
+        "type": "string",
+        "description": "Keyword associated with your premium service."
+      },
+      "enqueue": {
+        "type": "integer",
+        "enum": [0, 1],
+        "default": 1,
+        "description": "Set to 1 to queue the message without waiting for telco acknowledgement (default)."
+      },
+      "linkId": {
+        "type": "string",
+        "description": "Link ID for on-demand premium SMS — echoed back in the delivery report callback."
+      },
+      "retryDurationInHours": {
+        "type": "integer",
+        "description": "Number of hours to retry delivery for premium SMS."
+      },
+      "requestId": {
+        "type": "string",
+        "description": "Optional correlation ID echoed back in the HTTP DLR callback. Use to match delivery reports to your sends."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "required": ["SMSMessageData"],
+    "properties": {
+      "SMSMessageData": {
+        "type": "object",
+        "required": ["Message", "Recipients"],
+        "properties": {
+          "Message": {
+            "type": "string",
+            "description": "Summary message (e.g. \"Sent to 1/1 Total Cost: KES 0.8000\")."
+          },
+          "Recipients": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["statusCode", "number", "status", "cost", "messageId"],
+              "properties": {
+                "statusCode": {
+                  "type": "integer",
+                  "description": "Per-recipient delivery status code. 101=Sent, 102=Queued, 100=Processed, 401=RiskHold, 402=InvalidSenderId, 403=InvalidPhoneNumber, 404=UnsupportedNumberType, 405=InsufficientBalance, 406=UserInBlacklist, 407=CouldNotRoute, 409=DoNotDisturbRejection, 500=InternalServerError, 501=GatewayError, 502=RejectedByGateway."
+                },
+                "number": {
+                  "type": "string",
+                  "description": "Recipient phone number in E.164 format."
+                },
+                "status": {
+                  "type": "string",
+                  "description": "Human-readable status (e.g. \"Success\", \"DeliveryFailure\")."
+                },
+                "cost": {
+                  "type": "string",
+                  "description": "Cost for this recipient (e.g. \"KES 0.8000\")."
+                },
+                "messageId": {
+                  "type": "string",
+                  "description": "Unique message ID assigned by Africa's Talking."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "string",
+    "description": "HTTP 4xx responses return a plain error message string."
+  },
+  "gotchas": [
+    "Production URL is content.africastalking.com, NOT api.africastalking.com. Using the wrong domain will fail. Sandbox still uses api.sandbox.africastalking.com.",
+    "from (your registered shortcode) is required for premium SMS — unlike bulk SMS where the sender ID is optional.",
+    "Use requestId to correlate delivery reports with your sends. Africa's Talking echoes it back in the HTTP DLR callback."
+  ]
+}

--- a/specs/sms/africastalking/send_sms/canonical_example.ts
+++ b/specs/sms/africastalking/send_sms/canonical_example.ts
@@ -1,0 +1,111 @@
+/**
+ * @provider Africa's Talking
+ * @capability send_sms
+ * @atss 1.0
+ * @capability_type synchronous
+ */
+
+const AFRICASTALKING_API_KEY = process.env.AFRICASTALKING_API_KEY;
+const AFRICASTALKING_USERNAME = process.env.AFRICASTALKING_USERNAME;
+if (!AFRICASTALKING_API_KEY) throw new Error("Missing env: AFRICASTALKING_API_KEY");
+if (!AFRICASTALKING_USERNAME) throw new Error("Missing env: AFRICASTALKING_USERNAME");
+
+const IS_SANDBOX = process.env.AFRICASTALKING_SANDBOX === "true";
+const BASE_URL = IS_SANDBOX
+  ? "https://api.sandbox.africastalking.com/version1/messaging"
+  : "https://api.africastalking.com/version1/messaging";
+
+interface SendSmsInput {
+  to: string | string[];
+  message: string;
+  from?: string;
+  bulkSMSMode?: number;
+  enqueue?: number;
+}
+
+interface SmsRecipient {
+  statusCode: number;
+  number: string;
+  status: string;
+  cost: string;
+  messageId: string;
+}
+
+interface SendSmsResponse {
+  SMSMessageData: {
+    Message: string;
+    Recipients: SmsRecipient[];
+  };
+}
+
+export async function sendSms(input: SendSmsInput): Promise<SendSmsResponse> {
+  const to = Array.isArray(input.to) ? input.to.join(",") : input.to;
+
+  const params = new URLSearchParams();
+  // In sandbox mode, username must be the literal string "sandbox"
+  params.set("username", IS_SANDBOX ? "sandbox" : AFRICASTALKING_USERNAME!);
+  params.set("to", to);
+  params.set("message", input.message);
+  if (input.from !== undefined) params.set("from", input.from);
+  if (input.bulkSMSMode !== undefined) params.set("bulkSMSMode", String(input.bulkSMSMode));
+  if (input.enqueue !== undefined) params.set("enqueue", String(input.enqueue));
+
+  const response = await fetch(BASE_URL, {
+    method: "POST",
+    headers: {
+      apiKey: AFRICASTALKING_API_KEY!,
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Africa's Talking error ${response.status}: ${errorText}`);
+  }
+
+  const result = (await response.json()) as SendSmsResponse;
+
+  // HTTP 200 does not guarantee delivery — check per-recipient statusCode
+  for (const recipient of result.SMSMessageData.Recipients) {
+    if (recipient.statusCode !== 101 && recipient.statusCode !== 102 && recipient.statusCode !== 100) {
+      console.warn(
+        `Recipient ${recipient.number} failed: statusCode=${recipient.statusCode} status=${recipient.status}`
+      );
+    }
+  }
+
+  return result;
+}
+
+/*
+Usage example:
+
+// Set env vars:
+//   AFRICASTALKING_API_KEY=your_key
+//   AFRICASTALKING_USERNAME=your_username
+//   AFRICASTALKING_SANDBOX=true   (omit or set to "false" for production)
+
+const result = await sendSms({
+  to: ["+254711XXXYYY", "+254733YYYZZZ"],
+  message: "Your order #123 has been confirmed.",
+  from: "MyApp",      // optional registered shortcode
+  bulkSMSMode: 1,     // required for bulk sends
+  enqueue: 1,         // queue without waiting for telco ACK
+});
+
+console.log(result.SMSMessageData.Message);
+// "Sent to 2/2 Total Cost: KES 1.6000"
+
+for (const r of result.SMSMessageData.Recipients) {
+  console.log(`${r.number}: statusCode=${r.statusCode} cost=${r.cost}`);
+  // statusCode 101 = Sent (success)
+  // statusCode 403 = InvalidPhoneNumber — ensure E.164 with + prefix
+}
+
+// NOTE: The API always returns HTTP 200 even on per-recipient failures.
+// Always check SMSMessageData.Recipients[].statusCode for each number.
+// In sandbox, DeliveryFailure means the AT Simulator at
+// https://simulator.africastalking.com is not logged in.
+*/

--- a/specs/sms/africastalking/send_sms/schema.json
+++ b/specs/sms/africastalking/send_sms/schema.json
@@ -1,0 +1,123 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "2024-01-01",
+  "capability": "send_sms",
+  "capability_type": "synchronous",
+  "status": "ready",
+  "currency": ["KES", "NGN", "TZS", "UGX", "RWF", "MWK"],
+  "auth": {
+    "type": "api_key",
+    "location": "header",
+    "field": "apiKey",
+    "format": "{token}",
+    "env_var": "AFRICASTALKING_API_KEY"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "https://api.africastalking.com/version1/messaging"
+  },
+  "example_prompt": "Send a bulk SMS to one or more phone numbers using Africa's Talking legacy endpoint (supports sandbox).",
+  "input_schema": {
+    "type": "object",
+    "required": ["username", "to", "message"],
+    "properties": {
+      "username": {
+        "type": "string",
+        "description": "Your Africa's Talking app username. Must be the literal string \"sandbox\" when using the sandbox environment."
+      },
+      "to": {
+        "type": "string",
+        "description": "Comma-separated E.164 phone numbers (e.g. \"+254711XXXYYY,+254733YYYZZZ\"). Each number must include the + prefix."
+      },
+      "message": {
+        "type": "string",
+        "description": "SMS content to send. Must not contain % characters — they fail silently at the carrier level."
+      },
+      "from": {
+        "type": "string",
+        "description": "Registered shortcode or alphanumeric sender ID. Defaults to AFRICASTKNG if omitted."
+      },
+      "bulkSMSMode": {
+        "type": "integer",
+        "enum": [0, 1],
+        "default": 1,
+        "description": "Set to 1 for bulk SMS (default). Must be 1 when sending to multiple recipients."
+      },
+      "enqueue": {
+        "type": "integer",
+        "enum": [0, 1],
+        "default": 1,
+        "description": "Set to 1 to queue the message without waiting for telco acknowledgement (default)."
+      },
+      "keyword": {
+        "type": "string",
+        "description": "Keyword for premium SMS service."
+      },
+      "linkId": {
+        "type": "string",
+        "description": "Link ID for premium on-demand SMS."
+      },
+      "retryDurationInHours": {
+        "type": "integer",
+        "description": "Number of hours to retry delivery for premium SMS."
+      }
+    }
+  },
+  "response_schema": {
+    "type": "object",
+    "required": ["SMSMessageData"],
+    "properties": {
+      "SMSMessageData": {
+        "type": "object",
+        "required": ["Message", "Recipients"],
+        "properties": {
+          "Message": {
+            "type": "string",
+            "description": "Summary message (e.g. \"Sent to 1/1 Total Cost: KES 0.8000\")."
+          },
+          "Recipients": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["statusCode", "number", "status", "cost", "messageId"],
+              "properties": {
+                "statusCode": {
+                  "type": "integer",
+                  "description": "Per-recipient delivery status code. 101=Sent, 102=Queued, 100=Processed, 401=RiskHold, 402=InvalidSenderId, 403=InvalidPhoneNumber, 404=UnsupportedNumberType, 405=InsufficientBalance, 406=UserInBlacklist, 407=CouldNotRoute, 409=DoNotDisturbRejection, 500=InternalServerError, 501=GatewayError, 502=RejectedByGateway."
+                },
+                "number": {
+                  "type": "string",
+                  "description": "Recipient phone number in E.164 format."
+                },
+                "status": {
+                  "type": "string",
+                  "description": "Human-readable status (e.g. \"Success\", \"DeliveryFailure\")."
+                },
+                "cost": {
+                  "type": "string",
+                  "description": "Cost for this recipient (e.g. \"KES 0.8000\")."
+                },
+                "messageId": {
+                  "type": "string",
+                  "description": "Unique message ID assigned by Africa's Talking."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "error_schema": {
+    "type": "string",
+    "description": "HTTP 4xx responses return a plain error message string."
+  },
+  "gotchas": [
+    "In sandbox, DeliveryFailure means the AT Simulator is not active or not logged in. Open https://simulator.africastalking.com and log in before testing — the API returns 200 but nothing is delivered without the simulator running.",
+    "The username field must be the literal string \"sandbox\" when using the sandbox environment — not your real username. Sandbox API keys are separate from production keys; both are in the AT dashboard.",
+    "Messages containing % fail silently at the carrier level. Strip or replace % characters before passing to message.",
+    "Request body must be application/x-www-form-urlencoded. Use URLSearchParams to encode the body — sending JSON.stringify() causes a 400 or silent failure.",
+    "The API always returns HTTP 200 even when messages fail per recipient. Check SMSMessageData.Recipients[].statusCode — 101 means Sent; anything else is a failure for that recipient.",
+    "Phone numbers must be full E.164 format with + prefix (e.g. +254712345678). Local formats without + return statusCode 403 (InvalidPhoneNumber)."
+  ]
+}

--- a/specs/sms/africastalking/send_sms/schema.json
+++ b/specs/sms/africastalking/send_sms/schema.json
@@ -118,6 +118,7 @@
     "Messages containing % fail silently at the carrier level. Strip or replace % characters before passing to message.",
     "Request body must be application/x-www-form-urlencoded. Use URLSearchParams to encode the body — sending JSON.stringify() causes a 400 or silent failure.",
     "The API always returns HTTP 200 even when messages fail per recipient. Check SMSMessageData.Recipients[].statusCode — 101 means Sent; anything else is a failure for that recipient.",
-    "Phone numbers must be full E.164 format with + prefix (e.g. +254712345678). Local formats without + return statusCode 403 (InvalidPhoneNumber)."
+    "Phone numbers must be full E.164 format with + prefix (e.g. +254712345678). Local formats without + return statusCode 403 (InvalidPhoneNumber).",
+    "The default Africa's Talking sender ID only works in Kenya on Airtel numbers. For any other country or network, register a dedicated sender ID from the AT dashboard — otherwise messages will be rejected or undelivered."
   ]
 }

--- a/specs/sms/africastalking/send_sms/schema.json
+++ b/specs/sms/africastalking/send_sms/schema.json
@@ -4,7 +4,7 @@
   "capability": "send_sms",
   "capability_type": "synchronous",
   "status": "ready",
-  "currency": ["KES", "NGN", "TZS", "UGX", "RWF", "MWK"],
+  "currency": ["EGP", "GHS", "KES", "LSL", "MWK", "NAD", "NGN", "RWF", "SZL", "TZS", "UGX", "XOF", "ZAR", "ZMW"],
   "auth": {
     "type": "api_key",
     "location": "header",

--- a/specs/sms/africastalking/webhook_bulk_opt_out/canonical_example.ts
+++ b/specs/sms/africastalking/webhook_bulk_opt_out/canonical_example.ts
@@ -1,0 +1,48 @@
+/**
+ * @provider Africa's Talking
+ * @capability webhook_bulk_opt_out
+ * @atss 1.0
+ * @capability_type webhook
+ */
+
+// Webhook payload types received from Africa's Talking
+// AT POSTs as application/x-www-form-urlencoded
+
+interface BulkOptOutPayload {
+  senderId: string;
+  phoneNumber: string;
+}
+
+// Handler function — wire this to your web framework's POST route
+export function handleBulkOptOut(payload: BulkOptOutPayload): void {
+  const { senderId, phoneNumber } = payload;
+
+  // IMPORTANT: You must honor this opt-out.
+  // Store the opted-out phone number and exclude it from future sends
+  // to avoid being flagged as a spammer.
+  console.log(`Opt-out received: ${phoneNumber} opted out from sender ${senderId}`);
+
+  // Add to your opt-out list (example: database update)
+  // await db.optOuts.upsert({ phoneNumber, senderId, optedOutAt: new Date() });
+}
+
+/*
+Usage (Express example):
+
+import express from "express";
+const app = express();
+
+app.post("/sms/opt-out", express.urlencoded({ extended: true }), (req, res) => {
+  // Always respond 200 immediately
+  res.sendStatus(200);
+  handleBulkOptOut(req.body as BulkOptOutPayload);
+});
+
+Configure callback URL: AT Dashboard → SMS → SMS Callback URLs → Bulk SMS Opt Out
+
+Notes:
+- AT sends payloads as application/x-www-form-urlencoded (not JSON)
+- AT automatically appends opt-out instructions to the FIRST message sent to each subscriber
+- Subsequent messages to the same subscriber are sent without the opt-out instructions
+- You must honor opt-outs — failure to do so risks being flagged as a spammer
+*/

--- a/specs/sms/africastalking/webhook_bulk_opt_out/schema.json
+++ b/specs/sms/africastalking/webhook_bulk_opt_out/schema.json
@@ -4,7 +4,7 @@
   "capability": "webhook_bulk_opt_out",
   "capability_type": "webhook",
   "status": "draft",
-  "currency": ["KES", "MWK", "NGN", "RWF", "TZS", "UGX"],
+  "currency": ["EGP", "GHS", "KES", "LSL", "MWK", "NAD", "NGN", "RWF", "SZL", "TZS", "UGX", "XOF", "ZAR", "ZMW"],
   "auth": {
     "type": "none"
   },

--- a/specs/sms/africastalking/webhook_bulk_opt_out/schema.json
+++ b/specs/sms/africastalking/webhook_bulk_opt_out/schema.json
@@ -1,0 +1,36 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "2024-01-01",
+  "capability": "webhook_bulk_opt_out",
+  "capability_type": "webhook",
+  "status": "draft",
+  "currency": ["KES", "MWK", "NGN", "RWF", "TZS", "UGX"],
+  "auth": {
+    "type": "none"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "{your_webhook_url}"
+  },
+  "example_prompt": "Handle bulk SMS opt-out notifications from Africa's Talking subscribers.",
+  "input_schema": {},
+  "response_schema": {
+    "type": "object",
+    "required": ["senderId", "phoneNumber"],
+    "properties": {
+      "senderId": {
+        "type": "string",
+        "description": "The shortcode or alphanumeric sender ID that the subscriber opted out from."
+      },
+      "phoneNumber": {
+        "type": "string",
+        "description": "Phone number of the subscriber who opted out."
+      }
+    }
+  },
+  "error_schema": {},
+  "gotchas": [
+    "Africa's Talking automatically appends opt-out instructions to the first message you send to each subscriber. Subsequent messages are sent as-is without the instructions.",
+    "You must honor opt-outs. Store opted-out phone numbers and exclude them from future sends to avoid being flagged as a spammer."
+  ]
+}

--- a/specs/sms/africastalking/webhook_delivery_report/canonical_example.ts
+++ b/specs/sms/africastalking/webhook_delivery_report/canonical_example.ts
@@ -1,0 +1,77 @@
+/**
+ * @provider Africa's Talking
+ * @capability webhook_delivery_report
+ * @atss 1.0
+ * @capability_type webhook
+ */
+
+// Webhook payload types received from Africa's Talking
+// AT POSTs as application/x-www-form-urlencoded
+
+type DeliveryStatus =
+  | "Sent"
+  | "Submitted"
+  | "Buffered"
+  | "Rejected"
+  | "Success"
+  | "Failed"
+  | "AbsentSubscriber"
+  | "Expired";
+
+type FailureReason =
+  | "InsufficientCredit"
+  | "InvalidLinkId"
+  | "UserIsInactive"
+  | "UserInBlackList"
+  | "UserAccountSuspended"
+  | "NotNetworkSubcriber"
+  | "UserNotSubscribedToProduct"
+  | "UserDoesNotExist"
+  | "DeliveryFailure"
+  | "DoNotDisturbRejection";
+
+interface DeliveryReportPayload {
+  id: string;
+  status: DeliveryStatus;
+  phoneNumber: string;
+  networkCode: string;
+  failureReason?: FailureReason;
+  retryCount?: string; // AT sends form-encoded — parse to integer if needed
+}
+
+// Handler function — wire this to your web framework's POST route
+export function handleDeliveryReport(payload: DeliveryReportPayload): void {
+  const { id, status, phoneNumber, networkCode, failureReason } = payload;
+
+  if (status === "Success") {
+    // Message delivered to handset
+    console.log(`SMS ${id} delivered to ${phoneNumber} via network ${networkCode}`);
+  } else if (status === "Failed" || status === "Rejected") {
+    // Handle failure — failureReason has details
+    console.log(`SMS ${id} failed for ${phoneNumber}: ${failureReason ?? "unknown reason"}`);
+  } else {
+    // Intermediate statuses: Sent, Submitted, Buffered, AbsentSubscriber, Expired
+    console.log(`SMS ${id} status update for ${phoneNumber}: ${status}`);
+  }
+}
+
+/*
+Usage (Express example):
+
+import express from "express";
+const app = express();
+
+app.post("/sms/delivery-report", express.urlencoded({ extended: true }), (req, res) => {
+  // Always respond 200 immediately — AT may retry on non-200 responses
+  res.sendStatus(200);
+  handleDeliveryReport(req.body as DeliveryReportPayload);
+});
+
+Configure callback URL: AT Dashboard → SMS → SMS Callback URLs → Delivery Reports
+
+Notes:
+- AT sends payloads as application/x-www-form-urlencoded (not JSON)
+- "Success" status means delivered to handset — distinct from the "Success" in send_sms response
+- failureReason is only present when status is "Rejected" or "Failed"
+- In sandbox, networkCode "99999" means Athena (AT's test network)
+*/

--- a/specs/sms/africastalking/webhook_delivery_report/schema.json
+++ b/specs/sms/africastalking/webhook_delivery_report/schema.json
@@ -1,0 +1,67 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "2024-01-01",
+  "capability": "webhook_delivery_report",
+  "capability_type": "webhook",
+  "status": "draft",
+  "currency": ["KES", "MWK", "NGN", "RWF", "TZS", "UGX"],
+  "auth": {
+    "type": "none"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "{your_webhook_url}"
+  },
+  "example_prompt": "Handle Africa's Talking delivery report webhooks to track SMS delivery status.",
+  "input_schema": {},
+  "response_schema": {
+    "type": "object",
+    "required": ["id", "status", "phoneNumber", "networkCode"],
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Message ID — same value as messageId returned in the send_sms response."
+      },
+      "status": {
+        "type": "string",
+        "enum": ["Sent", "Submitted", "Buffered", "Rejected", "Success", "Failed", "AbsentSubscriber", "Expired"],
+        "description": "Final delivery status of the message on the handset."
+      },
+      "phoneNumber": {
+        "type": "string",
+        "description": "Recipient's phone number."
+      },
+      "networkCode": {
+        "type": "string",
+        "description": "Telco network code (e.g. 63902 for Safaricom, 99999 for Athena sandbox)."
+      },
+      "failureReason": {
+        "type": "string",
+        "enum": [
+          "InsufficientCredit",
+          "InvalidLinkId",
+          "UserIsInactive",
+          "UserInBlackList",
+          "UserAccountSuspended",
+          "NotNetworkSubcriber",
+          "UserNotSubscribedToProduct",
+          "UserDoesNotExist",
+          "DeliveryFailure",
+          "DoNotDisturbRejection"
+        ],
+        "description": "Only present when status is Rejected or Failed. Reason the message could not be delivered."
+      },
+      "retryCount": {
+        "type": "integer",
+        "description": "Number of delivery retries. Only present for premium SMS."
+      }
+    }
+  },
+  "error_schema": {},
+  "gotchas": [
+    "Configure the callback URL in the AT dashboard (SMS → SMS Callback URLs → Delivery Reports), not in the API call. There is no per-request callback URL parameter.",
+    "The status field here is the final delivery status (did it reach the handset?) — different from the status field in the send_sms response (was the request accepted?). Success here means delivered to handset.",
+    "failureReason is only present when status is Rejected or Failed. Do not expect it in other cases.",
+    "In sandbox, networkCode 99999 means Athena — Africa's Talking's test network. This code only appears in sandbox."
+  ]
+}

--- a/specs/sms/africastalking/webhook_delivery_report/schema.json
+++ b/specs/sms/africastalking/webhook_delivery_report/schema.json
@@ -62,6 +62,7 @@
     "Configure the callback URL in the AT dashboard (SMS → SMS Callback URLs → Delivery Reports), not in the API call. There is no per-request callback URL parameter.",
     "The status field here is the final delivery status (did it reach the handset?) — different from the status field in the send_sms response (was the request accepted?). Success here means delivered to handset.",
     "failureReason is only present when status is Rejected or Failed. Do not expect it in other cases.",
-    "In sandbox, networkCode 99999 means Athena — Africa's Talking's test network. This code only appears in sandbox."
+    "In sandbox, networkCode 99999 means Athena — Africa's Talking's test network. This code only appears in sandbox.",
+    "DoNotDisturbRejection only applies to Nigeria: promotional sender IDs cannot send between 8am–8pm per NCC rules. AT returns HTTP 409 and statusCode 409 for those recipients — handle it separately from other failures."
   ]
 }

--- a/specs/sms/africastalking/webhook_delivery_report/schema.json
+++ b/specs/sms/africastalking/webhook_delivery_report/schema.json
@@ -4,7 +4,7 @@
   "capability": "webhook_delivery_report",
   "capability_type": "webhook",
   "status": "draft",
-  "currency": ["KES", "MWK", "NGN", "RWF", "TZS", "UGX"],
+  "currency": ["EGP", "GHS", "KES", "LSL", "MWK", "NAD", "NGN", "RWF", "SZL", "TZS", "UGX", "XOF", "ZAR", "ZMW"],
   "auth": {
     "type": "none"
   },

--- a/specs/sms/africastalking/webhook_incoming_sms/canonical_example.ts
+++ b/specs/sms/africastalking/webhook_incoming_sms/canonical_example.ts
@@ -1,0 +1,60 @@
+/**
+ * @provider Africa's Talking
+ * @capability webhook_incoming_sms
+ * @atss 1.0
+ * @capability_type webhook
+ */
+
+// Webhook payload types received from Africa's Talking
+// AT POSTs as application/x-www-form-urlencoded
+
+interface IncomingSmsPayload {
+  date: string;
+  from: string;
+  id: string;
+  linkId?: string; // Only present for on-demand premium SMS
+  text: string;
+  to: string;
+  cost: string; // Format: "KES 1.00"
+  networkCode: string;
+}
+
+// Handler function — wire this to your web framework's POST route
+export function handleIncomingSms(payload: IncomingSmsPayload): void {
+  const { id, from, to, text, date, linkId } = payload;
+
+  console.log(`Received SMS ${id} from ${from} to shortcode ${to} at ${date}: "${text}"`);
+
+  if (linkId) {
+    // On-demand premium SMS — user is requesting a service
+    // Must reply using send_premium_sms with this linkId
+    console.log(`On-demand premium SMS — linkId: ${linkId}. Use this in send_premium_sms reply.`);
+  }
+
+  // Process the message content
+  const command = text.trim().toUpperCase();
+  if (command === "HELP") {
+    // Reply to user via send_sms or send_premium_sms
+  }
+}
+
+/*
+Usage (Express example):
+
+import express from "express";
+const app = express();
+
+app.post("/sms/incoming", express.urlencoded({ extended: true }), (req, res) => {
+  // Always respond 200 immediately
+  res.sendStatus(200);
+  handleIncomingSms(req.body as IncomingSmsPayload);
+});
+
+Configure callback URL: AT Dashboard → SMS → SMS Callback URLs → Incoming Messages
+
+Notes:
+- AT sends payloads as application/x-www-form-urlencoded (not JSON)
+- AT strongly recommends this webhook over polling the fetch_messages endpoint
+- linkId is only present for on-demand premium SMS — pass it in send_premium_sms when replying
+- cost field format is "KES 1.00" — currency code + space + decimal amount
+*/

--- a/specs/sms/africastalking/webhook_incoming_sms/schema.json
+++ b/specs/sms/africastalking/webhook_incoming_sms/schema.json
@@ -4,7 +4,7 @@
   "capability": "webhook_incoming_sms",
   "capability_type": "webhook",
   "status": "draft",
-  "currency": ["KES", "MWK", "NGN", "RWF", "TZS", "UGX"],
+  "currency": ["EGP", "GHS", "KES", "LSL", "MWK", "NAD", "NGN", "RWF", "SZL", "TZS", "UGX", "XOF", "ZAR", "ZMW"],
   "auth": {
     "type": "none"
   },

--- a/specs/sms/africastalking/webhook_incoming_sms/schema.json
+++ b/specs/sms/africastalking/webhook_incoming_sms/schema.json
@@ -1,0 +1,60 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "2024-01-01",
+  "capability": "webhook_incoming_sms",
+  "capability_type": "webhook",
+  "status": "draft",
+  "currency": ["KES", "MWK", "NGN", "RWF", "TZS", "UGX"],
+  "auth": {
+    "type": "none"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "{your_webhook_url}"
+  },
+  "example_prompt": "Handle incoming SMS messages sent to your Africa's Talking shortcode.",
+  "input_schema": {},
+  "response_schema": {
+    "type": "object",
+    "required": ["date", "from", "id", "text", "to", "cost", "networkCode"],
+    "properties": {
+      "date": {
+        "type": "string",
+        "description": "ISO 8601 datetime when the message was received."
+      },
+      "from": {
+        "type": "string",
+        "description": "Sender's phone number."
+      },
+      "id": {
+        "type": "string",
+        "description": "Internal Africa's Talking message ID."
+      },
+      "linkId": {
+        "type": "string",
+        "description": "Only present for on-demand premium SMS responses. Pass this value in the linkId field of send_premium_sms when replying."
+      },
+      "text": {
+        "type": "string",
+        "description": "Message content sent by the user."
+      },
+      "to": {
+        "type": "string",
+        "description": "Your registered shortcode that received the message."
+      },
+      "cost": {
+        "type": "string",
+        "description": "Cost of the message in the format 'KES 1.00' (currency code + space + decimal amount)."
+      },
+      "networkCode": {
+        "type": "string",
+        "description": "Telco network code of the sender."
+      }
+    }
+  },
+  "error_schema": {},
+  "gotchas": [
+    "Configure the incoming messages callback URL in the AT dashboard, not in the API call. Africa's Talking strongly recommends this webhook over the fetch_messages polling endpoint.",
+    "linkId is only present for on-demand premium SMS — use its value in the linkId field of send_premium_sms when replying to the user's on-demand request."
+  ]
+}

--- a/specs/sms/africastalking/webhook_subscription/canonical_example.ts
+++ b/specs/sms/africastalking/webhook_subscription/canonical_example.ts
@@ -1,0 +1,57 @@
+/**
+ * @provider Africa's Talking
+ * @capability webhook_subscription
+ * @atss 1.0
+ * @capability_type webhook
+ */
+
+// Webhook payload types received from Africa's Talking
+// AT POSTs as application/x-www-form-urlencoded
+
+type UpdateType = "addition" | "deletion";
+
+interface SubscriptionPayload {
+  phoneNumber: string;
+  shortCode: string;
+  keyword: string;
+  updateType: UpdateType;
+}
+
+// Handler function — wire this to your web framework's POST route
+export function handleSubscription(payload: SubscriptionPayload): void {
+  const { phoneNumber, shortCode, keyword, updateType } = payload;
+
+  if (updateType === "addition") {
+    // New subscriber — add to your subscriber list
+    console.log(`New subscriber: ${phoneNumber} subscribed to ${shortCode}/${keyword}`);
+    // await db.subscribers.upsert({ phoneNumber, shortCode, keyword, subscribedAt: new Date() });
+  } else if (updateType === "deletion") {
+    // Unsubscribe — remove from your subscriber list
+    console.log(`Unsubscribe: ${phoneNumber} unsubscribed from ${shortCode}/${keyword}`);
+    // await db.subscribers.delete({ phoneNumber, shortCode, keyword });
+  }
+
+  // IMPORTANT: Africa's Talking does not expose a subscriber list API.
+  // This webhook is your only source of truth — maintain your own list.
+}
+
+/*
+Usage (Express example):
+
+import express from "express";
+const app = express();
+
+app.post("/sms/subscription", express.urlencoded({ extended: true }), (req, res) => {
+  // Always respond 200 immediately
+  res.sendStatus(200);
+  handleSubscription(req.body as SubscriptionPayload);
+});
+
+Configure callback URL: AT Dashboard → SMS → SMS Callback URLs → Subscription Notifications
+
+Notes:
+- AT sends payloads as application/x-www-form-urlencoded (not JSON)
+- updateType is "addition" (subscribe) or "deletion" (unsubscribe)
+- Africa's Talking does not expose a subscriber list API — maintain your own list
+  by recording every addition and deletion event from this webhook
+*/

--- a/specs/sms/africastalking/webhook_subscription/schema.json
+++ b/specs/sms/africastalking/webhook_subscription/schema.json
@@ -1,0 +1,44 @@
+{
+  "spec_version": "1.0",
+  "provider_api_version": "2024-01-01",
+  "capability": "webhook_subscription",
+  "capability_type": "webhook",
+  "status": "draft",
+  "currency": ["KES", "MWK", "NGN", "RWF", "TZS", "UGX"],
+  "auth": {
+    "type": "none"
+  },
+  "endpoint": {
+    "method": "POST",
+    "url": "{your_webhook_url}"
+  },
+  "example_prompt": "Handle premium SMS subscription and unsubscription notifications from Africa's Talking.",
+  "input_schema": {},
+  "response_schema": {
+    "type": "object",
+    "required": ["phoneNumber", "shortCode", "keyword", "updateType"],
+    "properties": {
+      "phoneNumber": {
+        "type": "string",
+        "description": "Phone number that subscribed or unsubscribed."
+      },
+      "shortCode": {
+        "type": "string",
+        "description": "The short code with the product the subscriber acted on."
+      },
+      "keyword": {
+        "type": "string",
+        "description": "The keyword of the product the subscriber acted on."
+      },
+      "updateType": {
+        "type": "string",
+        "enum": ["addition", "deletion"],
+        "description": "addition = new subscriber, deletion = unsubscribe."
+      }
+    }
+  },
+  "error_schema": {},
+  "gotchas": [
+    "updateType is either addition (new subscriber) or deletion (unsubscribe). Maintain your own subscriber list and update it accordingly on each notification — Africa's Talking does not expose a subscriber list API."
+  ]
+}

--- a/specs/sms/africastalking/webhook_subscription/schema.json
+++ b/specs/sms/africastalking/webhook_subscription/schema.json
@@ -4,7 +4,7 @@
   "capability": "webhook_subscription",
   "capability_type": "webhook",
   "status": "draft",
-  "currency": ["KES", "MWK", "NGN", "RWF", "TZS", "UGX"],
+  "currency": ["EGP", "GHS", "KES", "LSL", "MWK", "NAD", "NGN", "RWF", "SZL", "TZS", "UGX", "XOF", "ZAR", "ZMW"],
   "auth": {
     "type": "none"
   },


### PR DESCRIPTION
## Summary

- Adds Africa's Talking SMS provider (`specs/sms/africastalking/`) with 9 capabilities
- `send_sms` and `fetch_messages` set to `ready` (sandbox-verified via `test_live.py`)
- Remaining 7 capabilities set to `draft` pending sandbox availability or webhook testing
- Extends `scripts/test_live.py` with per-step `content_type` support (needed for AT's form-encoded endpoint)
- Fixes `specs/CLAUDE.md` status enum (`compliant` → `ready`)

## Capabilities

| Capability | Status | Notes |
|---|---|---|
| `send_sms` | ready | Legacy bulk endpoint, sandbox-verified |
| `fetch_messages` | ready | Sandbox-verified |
| `send_bulk_sms` | draft | New bulk endpoint, sandbox "coming soon" |
| `send_premium_sms` | draft | Different domain: `content.africastalking.com` |
| `create_subscription` | draft | Safaricom-specific, Kenya only |
| `webhook_delivery_report` | draft | |
| `webhook_incoming_sms` | draft | |
| `webhook_bulk_opt_out` | draft | |
| `webhook_subscription` | draft | |

## Test plan

- [x] `npm run validate` passes with 0 failures (only warnings for non-declared env vars)
- [x] All 9 `canonical_example.ts` files compile with `tsc --noEmit`
- [x] Live sandbox test: `send_sms` and `fetch_messages` verified against `api.sandbox.africastalking.com`
- [x] Key gotchas captured: simulator requirement, form-encoded body, per-recipient statusCode, `content.africastalking.com` domain for premium